### PR TITLE
Template Updates - content missing #957

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@
 - Added 8 new icons to the CAGov icons font
 - Added side navigation component
 - Added pagination to the icon search page
+- Added automatic "on this page" navigation component
 ## 6.0.8
 - Updated site structure and rebuild framework to use eleventy site generation #191
 - Replaced server site includes with njk includes and templates

--- a/pages/template-updates.html
+++ b/pages/template-updates.html
@@ -32,6 +32,7 @@ permalink: "template-updates.html"
       <li>Added 8 new icons to the CAGov icons font</li>
       <li>Added side navigation component</li>
       <li>Added pagination to the icon search page</li>
+      <li>Added automatic "on this page" navigation component</li>
      </ul>
     </td>
    </tr>

--- a/pages/template-updates.html
+++ b/pages/template-updates.html
@@ -24,6 +24,18 @@ permalink: "template-updates.html"
  </thead>
  <tbody>
   <tr>
+    <td class="text-bold font-size-16">6.0.9</td>
+    <td class="font-size-16">11-23-22</td>
+    <td>
+     <ul class="font-size-16">
+      <li>Updated alert banner</li>
+      <li>Added 8 new icons to the CAGov icons font</li>
+      <li>Added side navigation component</li>
+      <li>Added pagination to the icon search page</li>
+     </ul>
+    </td>
+   </tr>
+  <tr>
    <td class="text-bold font-size-16">6.0.8</td>
    <td class="font-size-16">7-30-22</td>
    <td>


### PR DESCRIPTION
- Update content for 6.0.9 release found [here](https://github.com/Office-of-Digital-Services/California-State-Web-Template-Website/blob/beta-dev/changelog.md)