### PR TITLE
Remove hyperlink from space

### DIFF
--- a/pages/sample/css-utility-css-classes.html
+++ b/pages/sample/css-utility-css-classes.html
@@ -28,8 +28,8 @@ permalink: "get-started/css-classes-shortcuts/utility-css-classes.html"
 
   <h1 class="mt-lg-0">Utility CSS classes</h1>
 
-  <p>Use our utility CSS classes to stylize your web elements. Additional shortcuts are available on<a
-    href="https://www.w3schools.com/bootstrap4/bootstrap_ref_all_classes.asp" target="_blank"> Bootstrap</a>.</p>
+  <p>Use our utility CSS classes to stylize your web elements. Additional shortcuts are available on <a
+    href="https://www.w3schools.com/bootstrap4/bootstrap_ref_all_classes.asp" target="_blank">Bootstrap</a>.</p>
 
   <cagov-accordion>
    <details>


### PR DESCRIPTION
- Remove underlined space character from anchor tag in css-utility-css-classes.html 