### PR TITLE
fixing canon link in sitemap

### DIFF
--- a/sitemap.xml
+++ b/sitemap.xml
@@ -56,7 +56,7 @@
 <url><loc>https://template.webstandards.ca.gov/components/social-media-icons.html</loc></url>
 <url><loc>https://template.webstandards.ca.gov/components/tabs.html</loc></url>
 <url><loc>https://template.webstandards.ca.gov/components/table.html</loc></url>
-<url><loc>https://template.webstandards.ca.gov/get-started/css-classes-shortcuts/index.html</loc></url>
+<url><loc>https://template.webstandards.ca.gov/get-started/css-classes-shortcuts/</loc></url>
 <url><loc>https://template.webstandards.ca.gov/get-started/css-classes-shortcuts/utility-css-classes.html</loc></url>
 <url><loc>https://template.webstandards.ca.gov/get-started/css-classes-shortcuts/gradient-backgrounds.html</loc></url>
 <url><loc>https://template.webstandards.ca.gov/get-started/css-classes-shortcuts/spacing.html</loc></url>


### PR DESCRIPTION
SEO.  Simplifying a sitemap link that was referenced without the index.html.

https://template.webstandards.ca.gov/get-started/css-classes-shortcuts/
vs
https://template.webstandards.ca.gov/get-started/css-classes-shortcuts/index.html