### PR TITLE
SEO blocking search results

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -1,4 +1,4 @@
 User-agent: *
 Allow: /
-
+Disallow: */serp.html
 Sitemap: https://template.webstandards.ca.gov/sitemap.xml


### PR DESCRIPTION
Google searches are indexing for all the searching people do.  We don't need to index search results.