### PR TITLE
Showing 404 message for 403

### DIFF
--- a/web.config
+++ b/web.config
@@ -13,6 +13,8 @@
       <httpErrors>
         <remove statusCode="404" />
         <error statusCode="404" path="404.html" />
+        <remove statusCode="403" />
+        <error statusCode="403" path="404.html" />
       </httpErrors>
     </system.webServer>
 </configuration>


### PR DESCRIPTION
Showing 404 page when a 403 error happens.  Any folder request without a default document (index.html) will show this.

samples in prod...
https://template.webstandards.ca.gov/components/index.html - 404 (correct)
https://template.webstandards.ca.gov/components/ - 403 (That's ok)