### PR TITLE
Web Accessibility Issues (FTB) #1180

### DIFF
--- a/pages/sample/alert.html
+++ b/pages/sample/alert.html
@@ -56,9 +56,9 @@ permalink: "components/alert.html"
      <div class="alert alert-dismissible alert-banner" role="alert">
       <div class="container">
        <img src="/images/alert-info.svg" alt="alert info icon">
-       <span class="alert-text"><span class="text-bold">New!</span> A new version of the State Web Template has
+       <span class="alert-text" id="info-alert-example"><span class="text-bold">New!</span> A new version of the State Web Template has
         launched. <span class="ca-gov-icon-pipe" aria-hidden="true"></span>
-        <a href="javascript:;">Upgrade now</a></span>
+        <a href="javascript:;" aria-labelledby="info-alert-example">Upgrade now</a></span>
        <button type="button" class="close ms-lg-auto" data-bs-dismiss="alert" aria-label="Close"><span
          class="ca-gov-icon-close-mark" aria-hidden="true"></span></button>
       </div>
@@ -69,10 +69,10 @@ permalink: "components/alert.html"
      <div class="alert alert-dismissible alert-banner" role="alert">
       <div class="container">
        <span class="alert-icon ca-gov-icon-warning-triangle text-warning" aria-hidden="true"></span>
-       <span class="alert-text"><span class="text-bold">Warning:</span> Our website may be impacted during upgrade.
+       <span class="alert-text" id="warning-alert-example"><span class="text-bold">Warning:</span> Our website may be impacted during upgrade.
         <span class="ca-gov-icon-pipe" aria-hidden="true"></span>
 
-        <a href="javascript:;">Learn more <span class="sr-only">about the impact</span></a></span>
+        <a href="javascript:;" aria-labelledby="warning-alert-example">Learn more <span class="sr-only">about the impact</span></a></span>
        <button type="button" class="close ms-lg-auto" data-bs-dismiss="alert" aria-label="Close"><span
          class="ca-gov-icon-close-mark" aria-hidden="true"></span></button>
       </div>
@@ -85,9 +85,9 @@ permalink: "components/alert.html"
      <div class="alert alert-dismissible alert-banner" role="alert">
       <div class="container">
        <img src="/images/alert-warning-diamond.svg" alt="alert warning icon">
-       <span class="alert-text"><span class="text-bold">Alert:</span> Our systems are currently down. <span
+       <span class="alert-text" id="danger-alert-example"><span class="text-bold">Alert:</span> Our systems are currently down. <span
          class="ca-gov-icon-pipe" aria-hidden="true"></span>
-        <a href="javascript:;">Learn more <span class="sr-only">about the incident</span></a></span>
+        <a href="javascript:;" aria-labelledby="danger-alert-example">Learn more <span class="sr-only">about the incident</span></a></span>
        <button type="button" class="close ms-lg-auto" data-bs-dismiss="alert" aria-label="Close"><span
          class="ca-gov-icon-close-mark" aria-hidden="true"></span></button>
       </div>
@@ -98,9 +98,9 @@ permalink: "components/alert.html"
      <div class="alert alert-dismissible alert-banner" role="alert">
       <div class="container">
        <img src="/images/alert-success.svg" alt="alert success icon">
-       <span class="alert-text"><span class="text-bold">Fixed.</span> Our systems are back up again. <span
+       <span class="alert-text" id="resolution-alert-example"><span class="text-bold">Fixed.</span> Our systems are back up again. <span
          class="ca-gov-icon-pipe" aria-hidden="true"></span>
-        <a href="javascript:;">Learn more <span class="sr-only">about the resolution</span></a></span>
+        <a href="javascript:;" aria-labelledby="resolution-alert-example">Learn more <span class="sr-only">about the resolution</span></a></span>
        <button type="button" class="close ms-lg-auto" data-bs-dismiss="alert" aria-label="Close"><span
          class="ca-gov-icon-close-mark" aria-hidden="true"></span></button>
       </div>


### PR DESCRIPTION
Fix for issue 7; tested with NVDA.
This fix allows screen reader to read alert text without adding focus to non-interactive element.

- Add ids for alert text
- Use aria-labelledby for screen reader support