### PR TITLE
Adding noindex support

### DIFF
--- a/pages/404.html
+++ b/pages/404.html
@@ -2,6 +2,7 @@
 title: 404
 layout: page.njk
 permalink: "404.html"
+noindex: True
 ---
 
 <div class="row">

--- a/pages/contact-us-thankyou.html
+++ b/pages/contact-us-thankyou.html
@@ -2,6 +2,7 @@
 title: Contact us thanks
 layout: one-col.njk
 permalink: "contact-us-thankyou.html"
+noindex: True
 ---
 
 <h1 class="mt-lg-0">Thank you for your response</h1>

--- a/pages/serp.html
+++ b/pages/serp.html
@@ -2,4 +2,5 @@
 title: Search Results
 layout: search.njk
 permalink: "serp.html"
+noindex: True
 ---

--- a/robots.txt
+++ b/robots.txt
@@ -1,4 +1,3 @@
 User-agent: *
 Allow: /
-Disallow: */serp.html
 Sitemap: https://template.webstandards.ca.gov/sitemap.xml

--- a/robots.txt
+++ b/robots.txt
@@ -1,3 +1,4 @@
 User-agent: *
 Allow: /
+
 Sitemap: https://template.webstandards.ca.gov/sitemap.xml

--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -6,7 +6,9 @@
   <meta name="Author" content="State of California" />
   <meta name="Description" content="Version 6 of the State Web Template is California's latest web design standard." />
   <meta name="Keywords" content="California, government" />
-
+{% if noindex %}
+  <meta name="robots" content="noindex">
+{% endif %}
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="HandheldFriendly" content="True">
   <meta name="MobileOptimized" content="320">

--- a/src/_includes/layouts/search.njk
+++ b/src/_includes/layouts/search.njk
@@ -3,6 +3,9 @@
 <head>
   <title>{{ title }}</title> 
   <meta charset="utf-8">
+{% if noindex %}
+  <meta name="robots" content="noindex">
+{% endif %}
   <meta name="Author" content="State of California" />
   <meta name="Description" content="State of California" />
   <meta name="Keywords" content="California, government" />


### PR DESCRIPTION
Adding support for `noindex: True` in the 11ty frontmatter so we can specify pages that should not be search indexed.