### PR TITLE
SEO fixing permalink for css classes shortcuts

### DIFF
--- a/pages/sample/css-classes-shortcuts.html
+++ b/pages/sample/css-classes-shortcuts.html
@@ -2,7 +2,7 @@
 title: CSS classes shortcuts
 landing: Get started
 layout: page.njk
-permalink: "get-started/css-classes-shortcuts/index.html"
+permalink: "get-started/css-classes-shortcuts/"
 ---
 
 


### PR DESCRIPTION
removing the "index.html" from the permalink to improve SEO canonical determination.