### PR TITLE
SEO - Hotfix

### DIFF
--- a/pages/404.html
+++ b/pages/404.html
@@ -2,6 +2,7 @@
 title: 404
 layout: page.njk
 permalink: "404.html"
+noindex: True
 ---
 
 <div class="row">

--- a/pages/contact-us-thankyou.html
+++ b/pages/contact-us-thankyou.html
@@ -2,6 +2,7 @@
 title: Contact us thanks
 layout: one-col.njk
 permalink: "contact-us-thankyou.html"
+noindex: True
 ---
 
 <h1 class="mt-lg-0">Thank you for your response</h1>

--- a/pages/sample/css-classes-shortcuts.html
+++ b/pages/sample/css-classes-shortcuts.html
@@ -2,7 +2,7 @@
 title: CSS classes shortcuts
 landing: Get started
 layout: page.njk
-permalink: "get-started/css-classes-shortcuts/index.html"
+permalink: "get-started/css-classes-shortcuts/"
 ---
 
 

--- a/pages/serp.html
+++ b/pages/serp.html
@@ -2,4 +2,5 @@
 title: Search Results
 layout: search.njk
 permalink: "serp.html"
+noindex: True
 ---

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -54,7 +54,7 @@
 <url><loc>https://template.webstandards.ca.gov/components/social-media-icons.html</loc></url>
 <url><loc>https://template.webstandards.ca.gov/components/tabs.html</loc></url>
 <url><loc>https://template.webstandards.ca.gov/components/table.html</loc></url>
-<url><loc>https://template.webstandards.ca.gov/get-started/css-classes-shortcuts/index.html</loc></url>
+<url><loc>https://template.webstandards.ca.gov/get-started/css-classes-shortcuts/</loc></url>
 <url><loc>https://template.webstandards.ca.gov/get-started/css-classes-shortcuts/utility-css-classes.html</loc></url>
 <url><loc>https://template.webstandards.ca.gov/get-started/css-classes-shortcuts/gradient-backgrounds.html</loc></url>
 <url><loc>https://template.webstandards.ca.gov/get-started/css-classes-shortcuts/spacing.html</loc></url>

--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -6,7 +6,9 @@
   <meta name="Author" content="State of California" />
   <meta name="Description" content="Version 6 of the State Web Template is California's latest web design standard." />
   <meta name="Keywords" content="California, government" />
-
+{% if noindex %}
+  <meta name="robots" content="noindex">
+{% endif %}
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="HandheldFriendly" content="True">
   <meta name="MobileOptimized" content="320">

--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -16,6 +16,9 @@
   <meta name="title" content="California State Web Template">
   <meta name="description" content="Version 6 of the State Web Template is California's latest web design standard.">
 
+  <!-- Canonical link, improves SEO -->
+  <link href="https://template.webstandards.ca.gov{{ ("/"+permalink).replace("//","/") if permalink }}" rel="canonical">
+
   <!-- Open Graph / Facebook -->
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://template.webstandards.ca.gov/">

--- a/src/_includes/layouts/search.njk
+++ b/src/_includes/layouts/search.njk
@@ -3,6 +3,9 @@
 <head>
   <title>{{ title }}</title> 
   <meta charset="utf-8">
+{% if noindex %}
+  <meta name="robots" content="noindex">
+{% endif %}
   <meta name="Author" content="State of California" />
   <meta name="Description" content="State of California" />
   <meta name="Keywords" content="California, government" />


### PR DESCRIPTION
Addressing a few issues with pages being misreported to SEO.
- noindex support for pages that shouldn't be indexed
- canonical meta for declaring the canonincal SEO page
- "css-classes-shortcuts" - reducing "index.html" to folder reference. (sitemap and template)