### PR TITLE
Sitemap fixes

### DIFF
--- a/pages/sample/colortheme.html
+++ b/pages/sample/colortheme.html
@@ -2,7 +2,7 @@
 title: Color Theme
 landing: Visual design
 layout: landing.njk
-permalink: "visual-design/color/index.html"
+permalink: "visual-design/color/"
 ---
 
 <div class="container p-t-md">

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -44,7 +44,6 @@
 <url><loc>https://template.webstandards.ca.gov/components/button.html</loc></url>
 <url><loc>https://template.webstandards.ca.gov/components/countdown-timer.html</loc></url>
 <url><loc>https://template.webstandards.ca.gov/components/form-elements.html</loc></url>
-<url><loc>https://template.webstandards.ca.gov/components/horizontal-rule.html</loc></url>
 <url><loc>https://template.webstandards.ca.gov/components/lists.html</loc></url>
 <url><loc>https://template.webstandards.ca.gov/components/modal.html</loc></url>
 <url><loc>https://template.webstandards.ca.gov/components/number-counter.html</loc></url>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -44,6 +44,7 @@
 <url><loc>https://template.webstandards.ca.gov/components/button.html</loc></url>
 <url><loc>https://template.webstandards.ca.gov/components/countdown-timer.html</loc></url>
 <url><loc>https://template.webstandards.ca.gov/components/form-elements.html</loc></url>
+<url><loc>https://template.webstandards.ca.gov/components/horizontal-separator.html</loc></url>
 <url><loc>https://template.webstandards.ca.gov/components/lists.html</loc></url>
 <url><loc>https://template.webstandards.ca.gov/components/modal.html</loc></url>
 <url><loc>https://template.webstandards.ca.gov/components/number-counter.html</loc></url>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -36,7 +36,6 @@
 <url><loc>https://template.webstandards.ca.gov/structure/search.html</loc></url>
 <url><loc>https://template.webstandards.ca.gov/structure/site-navigation.html</loc></url>
 <url><loc>https://template.webstandards.ca.gov/structure/footer.html</loc></url>
-<url><loc>https://template.webstandards.ca.gov/structure/layouts.html</loc></url>
 <url><loc>https://template.webstandards.ca.gov/components.html</loc></url>
 <url><loc>https://template.webstandards.ca.gov/components/accordion.html</loc></url>
 <url><loc>https://template.webstandards.ca.gov/components/alert.html</loc></url>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -65,5 +65,4 @@
 <url><loc>https://template.webstandards.ca.gov/patterns/link-grid.html</loc></url>
 <url><loc>https://template.webstandards.ca.gov/patterns/progress-tracker.html</loc></url>
 <url><loc>https://template.webstandards.ca.gov/about.html</loc></url>
-<url><loc>https://template.webstandards.ca.gov/serp.html</loc></url>
 </urlset>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -50,7 +50,6 @@
 <url><loc>https://template.webstandards.ca.gov/components/page-navigation.html</loc></url>
 <url><loc>https://template.webstandards.ca.gov/components/parallax.html</loc></url>
 <url><loc>https://template.webstandards.ca.gov/components/progress-bar.html</loc></url>
-<url><loc>https://template.webstandards.ca.gov/components/site-navigation.html</loc></url>
 <url><loc>https://template.webstandards.ca.gov/components/social-media-icons.html</loc></url>
 <url><loc>https://template.webstandards.ca.gov/components/tabs.html</loc></url>
 <url><loc>https://template.webstandards.ca.gov/components/table.html</loc></url>


### PR DESCRIPTION
removing 4 files that shouldn't be indexed.
- https://template.webstandards.ca.gov/structure/layouts.html (404)
- https://template.webstandards.ca.gov/components/horizontal-rule.html (404)
- https://template.webstandards.ca.gov/components/site-navigation.html (404)
- https://template.webstandards.ca.gov/serp.html (not indexed)