### PR TITLE
6.1.2 mobl

### DIFF
--- a/src/_includes/layouts/navicons-landing.njk
+++ b/src/_includes/layouts/navicons-landing.njk
@@ -6,6 +6,10 @@
     <meta name="Author" content="State of California" />
     <meta name="Description" content="State of California" />
     <meta name="Keywords" content="California, government" />
+    <meta name="MobileOptimized" content="320" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, minimum-scale=1.0" />
     {% include "../head-js-css.njk" %}
   </head>
   <body class="primary">

--- a/src/_includes/layouts/navicons.njk
+++ b/src/_includes/layouts/navicons.njk
@@ -6,6 +6,10 @@
     <meta name="Author" content="State of California" />
     <meta name="Description" content="State of California" />
     <meta name="Keywords" content="California, government" />
+    <meta name="MobileOptimized" content="320" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, minimum-scale=1.0" />
     {% include "../head-js-css.njk" %}
   </head>
   <body class="primary">

--- a/src/_includes/layouts/search.njk
+++ b/src/_includes/layouts/search.njk
@@ -9,6 +9,7 @@
     <meta name="Author" content="State of California" />
     <meta name="Description" content="State of California" />
     <meta name="Keywords" content="California, government" />
+    <meta name="MobileOptimized" content="320" />
     <meta
       name="viewport"
       content="width=device-width, initial-scale=1.0, minimum-scale=1.0" />

--- a/src/_includes/mobile-controls.njk
+++ b/src/_includes/mobile-controls.njk
@@ -4,17 +4,17 @@
     <!-- Add more mobile controls here. These will be on the right side of the mobile page header section -->
   </span>
   <div class="mobile-control-group main-nav-icons">
+    {#
     <button class="mobile-control toggle-search">
       <span class="ca-gov-icon-search hidden-print" aria-hidden="true"></span>
       <span class="sr-only">Search</span>
     </button>
+    #}
     <button
       id="nav-icon3"
       class="mobile-control toggle-menu"
       aria-expanded="false"
-      aria-controls="navigation"
-      data-bs-toggle="collapse"
-      data-bs-target="#navigation">
+      aria-controls="navigation">
       <span></span>
       <span></span>
       <span></span>

--- a/src/js/cagov/mobile-controls.js
+++ b/src/js/cagov/mobile-controls.js
@@ -1,0 +1,206 @@
+//@ts-check
+
+(() => {
+  // VARIABLES
+  const bodyCont = document.querySelector("body");
+  const mainNav = document.querySelector(".main-navigation");
+  const navButton = document.querySelector(".toggle-menu");
+  const navSearchCont = document.querySelector(".navigation-search");
+  const mobileCntls = document.querySelector(".global-header .mobile-controls");
+  const mainCont = document.querySelector(".main-content");
+  const footerGlobal = document.querySelector("footer");
+  const footerSite = document.querySelector(".site-footer");
+  const siteSettings = document.querySelector(".site-settings");
+  const headerutility = document.querySelector(".utility-header");
+  const headerutilityLinksCont = document.querySelector(
+    ".utility-header .container .flex-row"
+  );
+  const navButtonCont = document.querySelector(
+    ".mobile-controls .main-nav-icons"
+  );
+  const siteBranding = document.querySelector(".branding");
+  const logoContainer = document.querySelector(".header-organization-banner");
+  const utilityLinks = document.querySelector(".settings-links");
+  let navDupLogo;
+  let mobileControlsDisplay = getComputedStyle(mobileCntls).display;
+  let allNavLinks;
+  let allUtilityLinks;
+  // We need timeout here to make sure navigation is created first (becasue naviagion.js is creating button elements dynamicaly) and then we can assign all thise links to our variable
+  setTimeout(() => {
+    allNavLinks = document.querySelectorAll(
+      '.navigation-search a.first-level-link, .navigation-search button.first-level-btn, .navigation-search input, .navigation-search button, .navigation-search [tabindex]:not([tabindex="-1"])'
+    );
+    allUtilityLinks = document.querySelectorAll(
+      '.settings-links a, .settings-links button, .settings-links input, .settings-links select, .settings-links [tabindex]:not([tabindex="-1"])'
+    );
+  }, 100);
+
+  // all focusable elements other than navigation
+  const allBodyLinks = document.querySelectorAll(
+    '.utility-header .social-media-links a, .utility-header .social-media-links input, .utility-header .social-media-links button, .utility-header .social-media-links [tabindex]:not([tabindex="-1"]), .site-settings button, .site-settings a, .site-settings [tabindex]:not([tabindex="-1"]), .branding a, .branding button, .branding input, .branding select, .main-content a[href], .main-content button, .main-content input, .main-content textarea, .main-content select, .main-content details, .main-content [tabindex]:not([tabindex="-1"]), .site-footer a[href], .site-footer button, .site-footer input, .site-footer textarea, .site-footer select, .site-footer details, .site-footer [tabindex]:not([tabindex="-1"]), footer a[href], footer button, footer input, footer textarea, footer select, footer details, footer [tabindex]:not([tabindex="-1"])'
+  );
+
+  // create container for drawer mobile nav items
+  const mobileItemsCont = document.createElement("div");
+  mobileItemsCont.setAttribute("class", "nav-drawer");
+
+  function duplicateLogo() {
+    const logoDup = document.createElement("div");
+    logoDup.setAttribute("class", "logo-nav");
+    logoDup.innerHTML = logoContainer.innerHTML;
+    return logoDup;
+  }
+
+  // move mobile navigation toggle button back into mobile controls container
+  function moveNavToggleButtonToMobileControlsContainer() {
+    setTimeout(() => {
+      navButton.setAttribute("aria-expanded", "false");
+      navButtonCont?.append(navButton);
+    }, 300);
+  }
+
+  // ONLOAD
+  window.onload = function () {
+    // move duplicated logo to navigation drawer section
+    navSearchCont?.prepend(mobileItemsCont);
+    mobileItemsCont?.prepend(duplicateLogo());
+    // assign logo link to nav the duplicate logo variable
+    navDupLogo = document.querySelector(".logo-nav a");
+    // if mobile
+    if (mobileControlsDisplay == "block") {
+      mobileNavDefault();
+      // if desktop
+    } else {
+      desktopNavDefault();
+    }
+  };
+
+  // Button click open and close menu function
+  function openMenu() {
+    mobileItemsCont.append(navButton);
+    navSearchCont?.classList.toggle("visible");
+    navSearchCont?.classList.toggle("not-visible");
+    // Open
+    if (navSearchCont?.classList.contains("visible")) {
+      navButton.setAttribute("aria-expanded", "true");
+      bodyCont?.classList.add("overflow-hidden");
+      navSearchCont?.setAttribute("aria-hidden", "false");
+      // make links focusable
+      allNavLinks?.forEach(el => {
+        el.removeAttribute("tabindex");
+      });
+      allUtilityLinks?.forEach(el => {
+        el.removeAttribute("tabindex");
+      });
+      // make all the rest of the links not focusable
+      allBodyLinks?.forEach(el => {
+        el.setAttribute("tabindex", "-1");
+      });
+      navDupLogo?.removeAttribute("tabindex");
+      // Hide all the website areas (add aria-hidden)
+      mainCont?.setAttribute("aria-hidden", "true");
+      footerGlobal?.setAttribute("aria-hidden", "true");
+      footerSite?.setAttribute("aria-hidden", "true");
+      siteSettings?.setAttribute("aria-hidden", "true");
+      headerutility?.setAttribute("aria-hidden", "true");
+      siteBranding?.setAttribute("aria-hidden", "true");
+
+      // Close
+    } else {
+      navButton.setAttribute("aria-expanded", "false");
+      bodyCont?.classList.remove("overflow-hidden");
+      navSearchCont?.setAttribute("aria-hidden", "true");
+      // removing focus
+      allNavLinks?.forEach(el => {
+        el.setAttribute("tabindex", "-1");
+      });
+      allUtilityLinks?.forEach(el => {
+        el.setAttribute("tabindex", "-1");
+      });
+      allBodyLinks?.forEach(el => {
+        el.removeAttribute("tabindex");
+      });
+      navDupLogo?.setAttribute("tabindex", "-1");
+      // remove aria hidden for the rest of the site
+      mainCont?.removeAttribute("aria-hidden");
+      footerGlobal?.removeAttribute("aria-hidden");
+      footerSite?.removeAttribute("aria-hidden");
+      siteSettings?.removeAttribute("aria-hidden");
+      headerutility?.removeAttribute("aria-hidden");
+      siteBranding?.removeAttribute("aria-hidden");
+      moveNavToggleButtonToMobileControlsContainer();
+    }
+  }
+
+  // Default state for mobile
+  function mobileNavDefault() {
+    moveNavToggleButtonToMobileControlsContainer();
+    mainNav?.before(utilityLinks);
+    bodyCont?.classList.remove("overflow-hidden");
+    navSearchCont?.classList.add("not-visible");
+    navSearchCont?.classList.remove("visible");
+    navSearchCont?.setAttribute("aria-hidden", "true");
+    // removing focus
+    allNavLinks?.forEach(el => {
+      el.setAttribute("tabindex", "-1");
+    });
+    allUtilityLinks?.forEach(el => {
+      el.setAttribute("tabindex", "-1");
+    });
+    allBodyLinks?.forEach(el => {
+      el.removeAttribute("tabindex");
+    });
+    navDupLogo?.setAttribute("tabindex", "-1");
+    // remove aria hidden for the rest of the site
+    mainCont?.removeAttribute("aria-hidden");
+    footerGlobal?.removeAttribute("aria-hidden");
+    footerSite?.removeAttribute("aria-hidden");
+    siteSettings?.removeAttribute("aria-hidden");
+    headerutility?.removeAttribute("aria-hidden");
+    siteBranding?.removeAttribute("aria-hidden");
+  }
+
+  // Default state for desktop
+  function desktopNavDefault() {
+    moveNavToggleButtonToMobileControlsContainer();
+    headerutilityLinksCont?.append(utilityLinks);
+    bodyCont?.classList.remove("overflow-hidden");
+    navSearchCont?.classList.add("visible");
+    navSearchCont?.classList.remove("not-visible");
+    navSearchCont?.setAttribute("aria-hidden", "false");
+    allNavLinks?.forEach(el => {
+      el.removeAttribute("tabindex");
+    });
+    allUtilityLinks?.forEach(el => {
+      el.removeAttribute("tabindex");
+    });
+    allBodyLinks?.forEach(el => {
+      el.removeAttribute("tabindex");
+    });
+    navDupLogo?.removeAttribute("tabindex");
+    // remove aria hidden for the rest of the site
+    mainCont?.removeAttribute("aria-hidden");
+    footerGlobal?.removeAttribute("aria-hidden");
+    footerSite?.removeAttribute("aria-hidden");
+    siteSettings?.removeAttribute("aria-hidden");
+    headerutility?.removeAttribute("aria-hidden");
+    siteBranding?.removeAttribute("aria-hidden");
+    // move logo back to branding section
+  }
+
+  // Button Click event
+  navButton.addEventListener("click", openMenu);
+
+  // on resize function (hide mobile nav)
+  window.addEventListener("resize", () => {
+    // set changing wariable in here
+    mobileControlsDisplay = getComputedStyle(mobileCntls).display;
+    // if mobile
+    if (mobileControlsDisplay == "block") {
+      mobileNavDefault();
+      // if desctop
+    } else {
+      desktopNavDefault();
+    }
+  });
+})();

--- a/src/js/cagov/mobile-controls.js
+++ b/src/js/cagov/mobile-controls.js
@@ -12,6 +12,7 @@
   const footerSite = document.querySelector(".site-footer");
   const siteSettings = document.querySelector(".site-settings");
   const headerutility = document.querySelector(".utility-header");
+  const regularHeader = document.querySelector("header");
   const headerutilityLinksCont = document.querySelector(
     ".utility-header .container .flex-row"
   );
@@ -19,9 +20,7 @@
     ".mobile-controls .main-nav-icons"
   );
   const siteBranding = document.querySelector(".branding");
-  const logoContainer = document.querySelector(".header-organization-banner");
   const utilityLinks = document.querySelector(".settings-links");
-  let navDupLogo;
   let mobileControlsDisplay = getComputedStyle(mobileCntls).display;
   let allNavLinks;
   let allUtilityLinks;
@@ -44,13 +43,6 @@
   const mobileItemsCont = document.createElement("div");
   mobileItemsCont.setAttribute("class", "nav-drawer");
 
-  function duplicateLogo() {
-    const logoDup = document.createElement("div");
-    logoDup.setAttribute("class", "logo-nav");
-    logoDup.innerHTML = logoContainer.innerHTML;
-    return logoDup;
-  }
-
   // move mobile navigation toggle button back into mobile controls container
   function moveNavToggleButtonToMobileControlsContainer() {
     setTimeout(() => {
@@ -63,9 +55,7 @@
   window.onload = function () {
     // move duplicated logo to navigation drawer section
     navSearchCont?.prepend(mobileItemsCont);
-    mobileItemsCont?.prepend(duplicateLogo());
-    // assign logo link to nav the duplicate logo variable
-    navDupLogo = document.querySelector(".logo-nav a");
+
     // if mobile
     if (mobileControlsDisplay == "block") {
       mobileNavDefault();
@@ -96,7 +86,6 @@
       allBodyLinks?.forEach(el => {
         el.setAttribute("tabindex", "-1");
       });
-      navDupLogo?.removeAttribute("tabindex");
       // Hide all the website areas (add aria-hidden)
       mainCont?.setAttribute("aria-hidden", "true");
       footerGlobal?.setAttribute("aria-hidden", "true");
@@ -104,7 +93,7 @@
       siteSettings?.setAttribute("aria-hidden", "true");
       headerutility?.setAttribute("aria-hidden", "true");
       siteBranding?.setAttribute("aria-hidden", "true");
-
+      regularHeader?.classList.add("nav-overlay");
       // Close
     } else {
       navButton.setAttribute("aria-expanded", "false");
@@ -120,7 +109,6 @@
       allBodyLinks?.forEach(el => {
         el.removeAttribute("tabindex");
       });
-      navDupLogo?.setAttribute("tabindex", "-1");
       // remove aria hidden for the rest of the site
       mainCont?.removeAttribute("aria-hidden");
       footerGlobal?.removeAttribute("aria-hidden");
@@ -128,6 +116,7 @@
       siteSettings?.removeAttribute("aria-hidden");
       headerutility?.removeAttribute("aria-hidden");
       siteBranding?.removeAttribute("aria-hidden");
+      regularHeader?.classList.remove("nav-overlay");
       moveNavToggleButtonToMobileControlsContainer();
     }
   }
@@ -150,7 +139,6 @@
     allBodyLinks?.forEach(el => {
       el.removeAttribute("tabindex");
     });
-    navDupLogo?.setAttribute("tabindex", "-1");
     // remove aria hidden for the rest of the site
     mainCont?.removeAttribute("aria-hidden");
     footerGlobal?.removeAttribute("aria-hidden");
@@ -158,6 +146,7 @@
     siteSettings?.removeAttribute("aria-hidden");
     headerutility?.removeAttribute("aria-hidden");
     siteBranding?.removeAttribute("aria-hidden");
+    regularHeader?.classList.remove("nav-overlay");
   }
 
   // Default state for desktop
@@ -177,7 +166,6 @@
     allBodyLinks?.forEach(el => {
       el.removeAttribute("tabindex");
     });
-    navDupLogo?.removeAttribute("tabindex");
     // remove aria hidden for the rest of the site
     mainCont?.removeAttribute("aria-hidden");
     footerGlobal?.removeAttribute("aria-hidden");
@@ -185,7 +173,7 @@
     siteSettings?.removeAttribute("aria-hidden");
     headerutility?.removeAttribute("aria-hidden");
     siteBranding?.removeAttribute("aria-hidden");
-    // move logo back to branding section
+    regularHeader?.classList.remove("nav-overlay");
   }
 
   // Button Click event

--- a/src/js/cagov/mobile-controls.js
+++ b/src/js/cagov/mobile-controls.js
@@ -154,7 +154,7 @@
     moveNavToggleButtonToMobileControlsContainer();
     headerutilityLinksCont?.append(utilityLinks);
     bodyCont?.classList.remove("overflow-hidden");
-    navSearchCont?.classList.add("visible");
+    navSearchCont?.classList.remove("visible");
     navSearchCont?.classList.remove("not-visible");
     navSearchCont?.setAttribute("aria-hidden", "false");
     allNavLinks?.forEach(el => {

--- a/src/js/cagov/navigation.js
+++ b/src/js/cagov/navigation.js
@@ -509,7 +509,6 @@
         .querySelectorAll(".rotate")
         .forEach((/**@type {HTMLElement} */ el) => (el.style.display = "none"));
       const nav = document.querySelector("#navigation");
-      nav.classList.remove("collapse");
       nav.removeAttribute("aria-hidden");
     }
   }
@@ -535,10 +534,6 @@
       newDiv.classList.add("has-sub-btn");
       item.replaceWith(newDiv);
     });
-
-    if (mobileView()) {
-      navigationJS.classList.add("collapse");
-    }
 
     const singleLevel = navigationJS.classList.contains("singleLevel");
     const setActiveLinkByFolder =
@@ -641,7 +636,6 @@
 
       //Collapse the nav when narrow
       const nav = document.querySelector("#navigation");
-      nav.classList.add("collapse");
       nav.classList.remove("show");
       nav.setAttribute("aria-hidden", "true");
 

--- a/src/js/cagov/navigation.js
+++ b/src/js/cagov/navigation.js
@@ -619,28 +619,16 @@
 
   // Do Navigation Reset function on window resize uless it's mobile device.
   window.addEventListener("resize", () => {
-    if (
-      navigator.userAgent.match(/Android/i) ||
-      navigator.userAgent.match(/webOS/i) ||
-      navigator.userAgent.match(/iPhone/i) ||
-      navigator.userAgent.match(/iPad/i) ||
-      navigator.userAgent.match(/iPod/i) ||
-      navigator.userAgent.match(/BlackBerry/i) ||
-      navigator.userAgent.match(/Windows Phone/i)
-    ) {
-      return false;
-    } else {
-      document
-        .querySelector(".toggle-menu")
-        .setAttribute("aria-expanded", "false");
+    document
+      .querySelector(".toggle-menu")
+      .setAttribute("aria-expanded", "false");
 
-      //Collapse the nav when narrow
-      const nav = document.querySelector("#navigation");
-      nav.classList.remove("show");
-      nav.setAttribute("aria-hidden", "true");
+    //Collapse the nav when narrow
+    const nav = document.querySelector("#navigation");
+    nav.classList.remove("show");
+    nav.setAttribute("aria-hidden", "true");
 
-      NavReset();
-    }
+    NavReset();
   });
 
   // Reset on escape

--- a/src/js/cagov/search.js
+++ b/src/js/cagov/search.js
@@ -118,17 +118,6 @@
         function (e) {
           e.preventDefault();
           searchText.focus();
-          // mobile
-          if (
-            mobileView_for_search() &&
-            !searchContainer.classList.contains("active")
-          ) {
-            window.scrollTo({
-              top: searchContainer.getBoundingClientRect().top,
-              left: 0,
-              behavior: "smooth"
-            });
-          }
 
           if (
             !featuredsearch &&
@@ -151,11 +140,6 @@
           }
 
           if (featuredsearch) removeSearchAttr();
-
-          if (mobileView_for_search() && featuredsearch) {
-            searchContainer.classList.toggle("active");
-            ariaHidden();
-          }
 
           // let the user know the input box is where they should search
           searchContainer.classList.add("play-animation");
@@ -200,11 +184,6 @@
       //        document.dispatchEvent('cagov.searchresults.hide'); // ???
 
       if (mobileView_for_search()) {
-        window.scrollTo({
-          top: 0,
-          left: 0,
-          behavior: "smooth"
-        });
         ariaHidden();
       }
     }
@@ -244,24 +223,6 @@
 
       if (searchContainer) searchContainer.setAttribute("aria-hidden", "true");
     }
-
-    // Mobile Search toggle
-    document.querySelector(".toggle-search").addEventListener("click", () => {
-      document.querySelector(".search-container").classList.toggle("active");
-
-      if (searchactive) {
-        removeSearchAttr();
-
-        searchText.focus();
-        window.scrollTo({
-          top: searchContainer.getBoundingClientRect().top,
-          left: 0,
-          behavior: "smooth"
-        });
-      } else {
-        setSearchAttr();
-      }
-    });
 
     // Make Search form tabable if it's featured
     if (searchContainer) {
@@ -319,19 +280,11 @@
   function ariaHidden() {
     if (searchContainer) {
       if (featuredsearch) {
-        if (mobileView_for_search()) {
-          searchContainer.setAttribute("aria-hidden", "true");
-          document.querySelector("[name='q']").setAttribute("tabindex", "-1");
-          document
-            .querySelector(".gsc-search-button")
-            .setAttribute("tabindex", "-1");
-        } else {
-          searchContainer.removeAttribute("aria-hidden");
-          document.querySelector("[name='q']").removeAttribute("tabindex");
-          document
-            .querySelector(".gsc-search-button")
-            .removeAttribute("tabindex");
-        }
+        searchContainer.removeAttribute("aria-hidden");
+        document.querySelector("[name='q']").removeAttribute("tabindex");
+        document
+          .querySelector(".gsc-search-button")
+          .removeAttribute("tabindex");
       } else {
         searchContainer.setAttribute("aria-hidden", "true");
       }

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -14,3 +14,4 @@ import "./cagov/side-navigation.js";
 import "./cagov/external-link.js";
 import "./cagov/page-navigation.js";
 import "./cagov/pagination.js";
+import "./cagov/mobile-controls.js";

--- a/src/scss/cagov/nav-megamenu.scss
+++ b/src/scss/cagov/nav-megamenu.scss
@@ -181,11 +181,13 @@ a.second-level-link {
   }
   // 991px
   @media (max-width: $screen-sm-max) {
-    &:first-child {
-      margin-top: 2px !important;
-    }
     // to make outline visible
-    padding: 10px 15px 10px 20px !important;
+    padding: 0.5rem 1rem 0.75rem 2rem !important;
+    color: $white;
+    &:hover,
+    &:focus {
+      color: $white;
+    }
   }
 }
 
@@ -397,7 +399,7 @@ a.second-level-link {
     display: block;
   }
   .second-level-nav > li {
-    border-right: 0px;
+    border: none;
   }
 }
 

--- a/src/scss/cagov/nav-mobile-controls.scss
+++ b/src/scss/cagov/nav-mobile-controls.scss
@@ -7,6 +7,92 @@
 // MOBILE
 // --------------------------------------------------
 // Hamburger menu to X transition
+header {
+  &::after {
+    content: "";
+    position: absolute;
+    width: 100vh;
+    height: 100vh;
+    background-color: rgba(0, 0, 0, 0.48);
+    top: 0;
+    left: 0;
+    opacity: 0;
+    visibility: hidden;
+    -webkit-transition: opacity 0.3s ease-in-out, visibility 0.3s ease-in-out;
+    transition: opacity 0.3s ease-in-out, visibility 0.3s ease-in-out;
+  }
+}
+header.nav-overlay {
+  &::after {
+    opacity: 1;
+    visibility: visible;
+  }
+}
+
+.nav-drawer {
+  display: flex;
+  padding: 0.5rem 1rem 1rem 1rem;
+  .toggle-menu {
+    margin-top: 0;
+    width: 2.75rem;
+    height: 2.75rem;
+    span {
+      background-color: $white;
+      width: 30px;
+      &:nth-child(2),
+      &:nth-child(3) {
+        top: 20px;
+      }
+    }
+    background-color: transparent;
+    border: none;
+
+    &[aria-expanded="false"] {
+      span {
+        &:nth-child(1) {
+          top: 15px;
+        }
+        &:nth-child(2),
+        &:nth-child(3) {
+          top: 25px;
+        }
+        &:nth-child(4) {
+          top: 35px;
+        }
+      }
+    }
+  }
+  @media (min-width: $screen-md-min) {
+    display: none;
+  }
+}
+.navigation-search .settings-links {
+  padding: 1rem;
+  a {
+    position: relative;
+    color: $white;
+    margin-left: 1rem;
+    margin-right: 1rem;
+    font-size: 1rem;
+  }
+  a:before {
+    content: "";
+    color: $white;
+    border: none;
+    margin: 0 0.75rem;
+    font-size: 1.125rem;
+    font-weight: 200;
+    position: absolute;
+    border-left: 1px solid $gray-200;
+    height: 70%;
+    top: 5px;
+    left: -1.95rem;
+  }
+  a:first-child:before {
+    display: none;
+  }
+}
+
 .toggle-menu {
   padding: 16px 8px;
   display: flex;
@@ -28,6 +114,7 @@
   min-width: 2.5rem;
   min-height: 2.5rem;
   margin-top: 1.3rem;
+  margin-left: auto;
 
   // Overvriting sr-only class to avoid strucural changes in mobile controls
 

--- a/src/scss/cagov/nav-mobile-controls.scss
+++ b/src/scss/cagov/nav-mobile-controls.scss
@@ -6,7 +6,87 @@
 //
 // MOBILE
 // --------------------------------------------------
+// Hamburger menu to X transition
+.toggle-menu {
+  padding: 16px 8px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  cursor: pointer;
+  color: $white;
+  position: relative;
+  -webkit-transform: rotate(0deg);
+  -moz-transform: rotate(0deg);
+  -o-transform: rotate(0deg);
+  transform: rotate(0deg);
+  -webkit-transition: 0.5s ease-in-out;
+  -moz-transition: 0.5s ease-in-out;
+  -o-transition: 0.5s ease-in-out;
+  transition: 0.5s ease-in-out;
+  cursor: pointer;
+  color: $white;
+  min-width: 2.5rem;
+  min-height: 2.5rem;
+  margin-top: 1.3rem;
 
+  // Overvriting sr-only class to avoid strucural changes in mobile controls
+
+  span {
+    height: 2px;
+    width: 20px;
+    display: block;
+    position: absolute;
+    border-radius: 5px;
+    opacity: 1;
+    -webkit-transform: rotate(0deg);
+    -moz-transform: rotate(0deg);
+    -o-transform: rotate(0deg);
+    transform: rotate(0deg);
+    -webkit-transition: 0.25s ease-in-out;
+    -moz-transition: 0.25s ease-in-out;
+    -o-transition: 0.25s ease-in-out;
+    transition: 0.25s ease-in-out;
+
+    &:nth-child(1) {
+      top: 2px;
+    }
+
+    &:nth-child(2),
+    &:nth-child(3) {
+      top: 9px;
+    }
+
+    &:nth-child(4) {
+      top: 16px;
+    }
+  }
+
+  &[aria-expanded="true"] {
+    span:nth-child(1) {
+      top: 12px;
+      width: 0%;
+    }
+
+    span:nth-child(2) {
+      -webkit-transform: rotate(45deg);
+      -moz-transform: rotate(45deg);
+      -o-transform: rotate(45deg);
+      transform: rotate(45deg);
+    }
+
+    span:nth-child(3) {
+      -webkit-transform: rotate(-45deg);
+      -moz-transform: rotate(-45deg);
+      -o-transform: rotate(-45deg);
+      transform: rotate(-45deg);
+    }
+
+    span:nth-child(4) {
+      top: 12px;
+      width: 0%;
+    }
+  }
+}
 // CONTAINER
 .mobile-controls {
   text-align: right; // move most menu controls to right
@@ -24,100 +104,6 @@
     padding-left: 16px;
     padding-right: 16px;
     line-height: 2.75rem;
-  }
-
-  // Hamburger menu to X transition
-  .toggle-menu {
-    padding: 16px 8px;
-    display: flex;
-    flex-direction: column;
-    cursor: pointer;
-    color: $white;
-    position: relative;
-    -webkit-transform: rotate(0deg);
-    -moz-transform: rotate(0deg);
-    -o-transform: rotate(0deg);
-    transform: rotate(0deg);
-    -webkit-transition: 0.5s ease-in-out;
-    -moz-transition: 0.5s ease-in-out;
-    -o-transition: 0.5s ease-in-out;
-    transition: 0.5s ease-in-out;
-    cursor: pointer;
-    color: $white;
-    top: 4px;
-
-    // Overvriting sr-only class to avoid strucural changes in mobile controls
-    span.sr-only {
-      height: unset !important;
-      width: unset !important;
-      position: relative !important;
-      clip: unset !important;
-      background: none !important;
-      color: $gray-600;
-      right: 0 !important;
-      display: inline-block !important;
-      padding-left: 0 !important;
-      top: 10px;
-    }
-
-    span {
-      margin-left: 0.75rem;
-      margin-right: 0;
-      height: 2px;
-      width: 20px;
-      display: block;
-      position: absolute;
-      background: $gray-600;
-      border-radius: 5px;
-      opacity: 1;
-      -webkit-transform: rotate(0deg);
-      -moz-transform: rotate(0deg);
-      -o-transform: rotate(0deg);
-      transform: rotate(0deg);
-      -webkit-transition: 0.25s ease-in-out;
-      -moz-transition: 0.25s ease-in-out;
-      -o-transition: 0.25s ease-in-out;
-      transition: 0.25s ease-in-out;
-
-      &:nth-child(1) {
-        top: 2px;
-      }
-
-      &:nth-child(2),
-      &:nth-child(3) {
-        top: 9px;
-      }
-
-      &:nth-child(4) {
-        top: 16px;
-      }
-    }
-
-    &[aria-expanded="true"] {
-      span:nth-child(1) {
-        top: 12px;
-        width: 0%;
-      }
-
-      span:nth-child(2) {
-        -webkit-transform: rotate(45deg);
-        -moz-transform: rotate(45deg);
-        -o-transform: rotate(45deg);
-        transform: rotate(45deg);
-      }
-
-      span:nth-child(3) {
-        -webkit-transform: rotate(-45deg);
-        -moz-transform: rotate(-45deg);
-        -o-transform: rotate(-45deg);
-        transform: rotate(-45deg);
-      }
-
-      span:nth-child(4) {
-        top: 12px;
-        width: 0%;
-      }
-    }
   }
 
   .toggle-search {
@@ -138,20 +124,6 @@
       font-size: 1.4rem;
       display: block;
       margin: 0 auto;
-    }
-
-    // Overvriting sr-only class to avoid strucural changes in mobile controls
-    span.sr-only {
-      height: unset !important;
-      width: unset !important;
-      position: relative !important;
-      clip: unset !important;
-      background: none !important;
-      color: $gray-600;
-      right: 0 !important;
-      display: inline-block !important;
-      padding-left: 5px !important;
-      bottom: 4px;
     }
 
     &:focus {
@@ -203,7 +175,7 @@
   align-items: center;
   z-index: 1;
   position: relative;
-  top: -75px;
+  top: -3.75rem;
 }
 
 /* mobile controls hack for IE because IE never dies */

--- a/src/scss/cagov/nav-mobile-controls.scss
+++ b/src/scss/cagov/nav-mobile-controls.scss
@@ -255,7 +255,6 @@ header.nav-overlay {
   }
 }
 
-// IOS Icons FIX
 .main-nav-icons {
   display: flex;
   justify-content: flex-end;
@@ -263,6 +262,8 @@ header.nav-overlay {
   z-index: 1;
   position: relative;
   top: -3.75rem;
+  width: 20%;
+  margin-left: auto;
 }
 
 /* mobile controls hack for IE because IE never dies */

--- a/src/scss/cagov/navigation.scss
+++ b/src/scss/cagov/navigation.scss
@@ -245,7 +245,7 @@
         color: $black;
         &:hover,
         &:focus {
-          color: $gray-800 !important;
+          color: $gray-800;
           background-color: $gray-100;
         }
         &::before {

--- a/src/scss/cagov/navigation.scss
+++ b/src/scss/cagov/navigation.scss
@@ -32,8 +32,21 @@
   position: relative;
   padding-left: 0;
   padding-right: 0;
+  z-index: 26;
+
   @media (max-width: $screen-sm-max) {
     border-bottom: 1px solid $gray-200;
+    position: fixed;
+    top: 0;
+    right: -100%;
+    max-width: 85%;
+    margin-right: 0;
+    padding: 0;
+    transition: right 0.5s ease-in-out;
+    &.visible {
+      opacity: 1;
+      right: 0;
+    }
   }
 }
 
@@ -139,6 +152,11 @@
     .carrot {
       font-size: 1rem;
     }
+  }
+
+  // hide mobile logo in desktop view
+  .logo-nav {
+    display: none;
   }
 }
 
@@ -268,6 +286,8 @@
 // --------------------------------------------------
 // 992px
 @media (min-width: $screen-md-min) {
+  // show mobile logo in desktop view
+
   .main-navigation {
     z-index: 25;
     // handle the edge case when their is no nav links
@@ -391,11 +411,6 @@
           }
         }
       }
-
-      #nav-item-search {
-        button.first-level-link {
-        }
-      }
     }
 
     .main-navigation {
@@ -416,6 +431,9 @@
 // 991px
 
 @media (max-width: $screen-sm-max) {
+  .logo-nav {
+    display: block;
+  }
   #navigation {
     clear: both;
     width: 100%;
@@ -438,9 +456,6 @@
   }
 
   .full-width-nav {
-    max-width: 100%;
-    padding: 0;
-
     #nav-item-search button.first-level-link {
       background: none;
       border: none;
@@ -531,23 +546,6 @@
     }
   }
 
-  .oc-inner {
-    // Dynamically added wrapper div
-    position: relative;
-    width: 100%;
-    height: 100%;
-    left: 0;
-    margin-left: 0;
-    -webkit-transition: margin-left 0.5s ease;
-    -moz-transition: margin-left 0.5s ease;
-    -o-transition: margin-left 0.5s ease;
-    transition: margin-left 0.5s ease;
-
-    .oc-menu-open & {
-      margin-left: 70%;
-    }
-  }
-
   .global-header .navigation-search.oc-menu {
     position: absolute;
     width: 70%;
@@ -562,38 +560,6 @@
   // .header-decoration is placed on top of regular page, produces dropshadow, prevents clicks on main page, and when clicked closes the menu.
   .header-decoration {
     display: none; // hide in mobile view by default
-  }
-
-  .oc-outer .header-decoration {
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    height: auto;
-    width: 100%;
-    background: none;
-    -webkit-box-shadow: -6px -1px 30px 0px rgba(5, 5, 5, 0.5);
-    -moz-box-shadow: -6px -1px 30px 0px rgba(5, 5, 5, 0.5);
-    box-shadow: -6px -1px 30px 0px rgba(5, 5, 5, 0.5);
-    cursor: alias;
-  }
-
-  .oc-outer.oc-menu-open .header-decoration {
-    display: block;
-  }
-
-  .navigation-search.oc-menu {
-    padding-top: 60px;
-  }
-
-  .oc-menu .mobile-control.toggle-search {
-    display: none;
-  }
-
-  .oc-menu .mobile-control.cagov-logo {
-    display: block;
-    line-height: 1;
-    position: absolute;
-    top: 5px;
   }
 }
 // END MOBILE NAVIGATION

--- a/src/scss/cagov/navigation.scss
+++ b/src/scss/cagov/navigation.scss
@@ -35,7 +35,6 @@
   z-index: 26;
 
   @media (max-width: $screen-sm-max) {
-    border-bottom: 1px solid $gray-200;
     position: fixed;
     top: 0;
     right: -100%;
@@ -43,6 +42,8 @@
     margin-right: 0;
     padding: 0;
     transition: right 0.5s ease-in-out;
+    height: 100%;
+    overflow-y: auto;
     &.visible {
       opacity: 1;
       right: 0;
@@ -191,7 +192,7 @@
         color: $black;
         &:hover,
         &:focus {
-          color: $gray-800 !important;
+          color: $gray-800;
           background-color: $gray-100;
         }
         &::before {
@@ -475,21 +476,18 @@
   }
   // For standard mobile menu and off canvas menu
   .top-level-nav .nav-item {
-    background-color: $white;
     margin-top: 0;
-    border-top: 1px solid $gray-200;
+    border-bottom: 1px solid $gray-200;
 
     &:first-child {
-      border-top: none;
+      border-top: 1px solid $gray-200;
     }
 
     .first-level-link,
     .first-level-btn {
-      &:first-child {
-        margin-top: 2px;
-      }
+      color: $white;
       display: block;
-      padding: 20px 0 20px 15px;
+      padding: 1rem 0 1rem 1rem;
       margin-right: 2px;
       margin-left: 2px;
       text-decoration: none;
@@ -546,17 +544,6 @@
     }
   }
 
-  .global-header .navigation-search.oc-menu {
-    position: absolute;
-    width: 70%;
-    //height: 100%;
-    left: -70%;
-    top: 0;
-    -webkit-transition: left 0.5s ease;
-    transition: left 0.5s ease;
-    overflow-y: auto; // allow menu to scroll if dynamic height reaches beyond page height
-    overflow-x: hidden;
-  }
   // .header-decoration is placed on top of regular page, produces dropshadow, prevents clicks on main page, and when clicked closes the menu.
   .header-decoration {
     display: none; // hide in mobile view by default
@@ -790,15 +777,16 @@
     top: 0;
     right: 0;
     font-size: 1.5rem !important;
-    line-height: 4rem !important;
-    width: 64px !important;
-    height: 64px !important;
+    line-height: 3.2rem !important;
+    width: 55px !important;
+    height: 55px !important;
     text-align: center;
     cursor: pointer;
     border: none;
     -moz-transition: all 0.2s ease !important;
     -webkit-transition: all 0.2s ease !important;
     transition: all 0.2s ease !important;
+    color: $white !important;
   }
 
   .first-level-btn[aria-expanded="true"] .rotate {
@@ -806,9 +794,9 @@
     -webkit-transform: rotate(90deg) !important;
     transform: rotate(90deg) !important;
     position: absolute;
-    width: 64px !important;
-    height: 64px !important;
-    line-height: 4rem !important;
+    width: 55px !important;
+    height: 55px !important;
+    line-height: 3rem !important;
     font-size: 1.5rem !important;
     top: 0;
     right: 0;
@@ -816,5 +804,6 @@
     -moz-transition: all 0.2s ease !important;
     -webkit-transition: all 0.2s ease !important;
     transition: all 0.2s ease !important;
+    color: $white !important;
   }
 }

--- a/src/scss/cagov/search.scss
+++ b/src/scss/cagov/search.scss
@@ -322,6 +322,7 @@ input[type="search"].search-textfield {
   @media (max-width: $screen-sm-max) {
     padding-right: 1rem;
     padding-left: 1rem;
+    max-height: 100%;
   }
 }
 

--- a/src/scss/cagov/search.scss
+++ b/src/scss/cagov/search.scss
@@ -334,7 +334,7 @@ input[type="search"].search-textfield {
   }
   .flexbox .featured-search {
     left: 0;
-    width: 80%;
+    width: 100%;
   }
 
   .featured-search.active {

--- a/src/scss/cagov/site-header.scss
+++ b/src/scss/cagov/site-header.scss
@@ -1,5 +1,5 @@
 /* -----------------------------------------
-   SITE HEADER -  /source/scss/cagov/site-header.scss
+   SITE HEADER -  /source/scss/cagov/site-header.scss (branding)
 ----------------------------------------- */
 
 .branding {
@@ -18,13 +18,17 @@
     -webkit-transition: all 0.3s;
     transition: all 0.3s; // Smooth transition for compact header
     padding-left: 15px;
+    // 991px
     @media (max-width: $screen-sm-max) {
       position: relative;
       max-width: 400px;
       margin-left: 1rem;
+      margin-right: 20%;
       padding-top: 0.5rem;
       padding-left: 0;
-      padding-bottom: 1rem;
+      padding-bottom: 0.5rem;
+      display: flex;
+      align-content: center;
     }
 
     img {
@@ -38,11 +42,14 @@
         // Beta 5.0 addition
         max-width: 225px;
       }
+
+      @media (max-width: $screen-sm-max) {
+        max-height: 44px;
+      }
     }
 
     // Move logo above navigation
     a {
-      z-index: 26; // navigation is 25
       position: relative;
       text-decoration: none;
       color: black;
@@ -55,10 +62,7 @@
       .logo-assets {
         display: flex;
         align-content: center;
-        flex-direction: column;
-        @media (min-width: $screen-sm-min) {
-          flex-direction: row;
-        }
+        flex-flow: wrap;
 
         .logo-img {
           max-width: 100%;
@@ -70,9 +74,7 @@
 
         .logo-text {
           padding-left: 5px;
-          @media (max-width: $screen-sm-max) {
-            padding-top: 0.5rem;
-          }
+          // 991px
           .logo-state {
             font-size: 1rem;
             font-family: "Public Sans", sans-serif;
@@ -83,6 +85,9 @@
             line-height: 1.2em;
             transition: all 0.3s;
             display: block;
+            @media (max-width: $screen-sm-max) {
+              font-size: 0.78125rem;
+            }
           }
           .logo-dept {
             font-size: 1.75rem;
@@ -95,6 +100,9 @@
             line-height: 1.2em;
             transition: all 0.3s;
             display: block;
+            @media (max-width: $screen-sm-max) {
+              font-size: 1rem;
+            }
           }
         }
 

--- a/src/scss/cagov/utility-header.scss
+++ b/src/scss/cagov/utility-header.scss
@@ -192,9 +192,6 @@
 }
 /* Hide utilities in mobile */
 @media (max-width: $screen-sm-max) {
-  .utility-header {
-    display: none;
-  }
   button[aria-controls="siteSettings"] {
     display: none;
   }

--- a/src/scss/cagov/utility-header.scss
+++ b/src/scss/cagov/utility-header.scss
@@ -10,13 +10,6 @@
   min-height: 42px; // beta 6.0 addition
   transition: all 0.3s ease;
 
-  @media (max-width: $screen-xs-max) {
-    min-height: 40px; // beta 6.0 addition
-    .container {
-      max-width: 100%;
-    }
-  }
-
   .half {
     @include make-sm-column(6);
     padding-top: 0; // beta 6.0 addition
@@ -88,16 +81,6 @@
     }
 
     @include text-right();
-    @media (max-width: $screen-xs-max) {
-      // @include font-size(1); // font size
-      font-size: $font-size-base;
-      @include text-right(); // beta 5.0 addition
-      padding-right: 0;
-    }
-
-    @media (min-width: $screen-xs-max) and (max-width: $screen-sm-max) {
-      padding-right: 0;
-    }
 
     @media (min-width: $screen-md-min) {
       padding-right: 5px;
@@ -110,18 +93,6 @@
     display: inline-block;
     text-decoration: none;
     padding-right: 4px;
-  }
-
-  @media (max-width: $screen-xs-max) {
-    .social-media-links {
-      li {
-        padding: 0 5px;
-      }
-    }
-
-    .header-cagov-logo img {
-      left: 10px;
-    }
   }
 
   .located-city-name {
@@ -171,11 +142,6 @@
           margin-top: 6px;
         }
 
-        @media (max-width: $screen-xs-max) {
-          margin-right: 0.4rem;
-          margin-left: 0;
-        }
-
         a {
           margin: 0;
           padding-top: 0;
@@ -196,16 +162,6 @@
 
       a {
         margin: 0px 10px 0 10px;
-
-        @media (max-width: $screen-xs-max) {
-          margin: 4px 4px 0 4px;
-        }
-      }
-
-      @media (max-width: $screen-xs-max) {
-        [class^="ca-gov-icon-"] {
-          font-size: 1rem;
-        }
       }
     }
 
@@ -220,11 +176,6 @@
       a {
         margin: 0 10px 0 10px;
         font-size: 0.95rem;
-
-        @media (max-width: $screen-xs-max) {
-          margin: 0 4px 0 4px;
-          padding: 0;
-        }
       }
 
       button {
@@ -237,5 +188,14 @@
         }
       }
     }
+  }
+}
+/* Hide utilities in mobile */
+@media (max-width: $screen-sm-max) {
+  .utility-header {
+    display: none;
+  }
+  button[aria-controls="siteSettings"] {
+    display: none;
   }
 }

--- a/src/scss/colortheme/cs-navigation.scss
+++ b/src/scss/colortheme/cs-navigation.scss
@@ -208,6 +208,26 @@ nav-item-search {
   }
 }
 
+@media (max-width: $screen-sm-max) {
+  .nav-item {
+    &.active {
+      .first-level-btn {
+        background-color: $mobile-drawer-active !important;
+        color: $white !important;
+        &:hover,
+        &:focus {
+          background-color: $mobile-drawer !important;
+          color: $white !important;
+        }
+        &::before,
+        &::after {
+          border-left: none !important;
+        }
+      }
+    }
+  }
+}
+
 .has-sub .rotate {
   color: $color-p2;
 }

--- a/src/scss/colortheme/cs-navigation.scss
+++ b/src/scss/colortheme/cs-navigation.scss
@@ -4,37 +4,6 @@
 ----------------------------------------- */
 
 //
-// MOBILE CONTROLS
-// --------------------------------------------------
-
-.mobile-controls {
-  background: $white;
-}
-
-.toggle-menu span {
-  background-color: $gray-600 !important;
-}
-
-.mobile-control {
-  color: $mobile-controls;
-
-  a {
-    color: $mobile-controls;
-    text-decoration: none;
-  }
-
-  &.toggle-sub-nav {
-    color: $color-p2;
-    background-color: darken($sub-nav-bg, 2%);
-    &:hover,
-    &:focus {
-      outline: none;
-      background-color: $sub-nav-bg; // should be the same as sub-nav background
-    }
-  }
-}
-
-//
 // NAVIGATION ACTIVE STYLE
 // --------------------------------------------------
 .nav-item,

--- a/src/scss/colortheme/cs-navigation.scss
+++ b/src/scss/colortheme/cs-navigation.scss
@@ -60,9 +60,27 @@ nav-item-search {
   &:focus {
     color: $gray-900;
   }
+  // 991
+  @media (max-width: $screen-sm-max) {
+    &.active {
+      background-color: $mobile-drawer-active !important;
+      color: $white !important;
+      &:hover,
+      &:focus {
+        background-color: $mobile-drawer !important;
+        color: $white !important;
+      }
+      &::before,
+      &::after {
+        border-left: none !important;
+      }
+    }
 
-  @media (max-width: $screen-xs-max) {
-    border-bottom: 1px solid $color-s1;
+    &:hover,
+    &:focus {
+      background-color: $mobile-drawer-active !important;
+      color: $white !important;
+    }
   }
 }
 
@@ -75,6 +93,17 @@ nav-item-search {
 
   [class^="ca-gov-icon-"] {
     color: $gray-700;
+  }
+  // 991px
+  @media (max-width: $screen-sm-max) {
+    background-color: $mobile-drawer;
+    &.active {
+      background-color: $mobile-drawer-active;
+      &:hover,
+      &:focus {
+        background-color: $mobile-drawer;
+      }
+    }
   }
 }
 
@@ -89,9 +118,9 @@ nav-item-search {
       background: #fff;
     }
 
-    @media (max-width: $screen-xs-max) {
-      border-right: none; // beta 5.0 addition (for accessible menu)
-      border-bottom: 1px solid $color-s1;
+    @media (max-width: $screen-sm-max) {
+      border: none; // beta 5.0 addition (for accessible menu)
+      border-top: 1px solid $gray-200;
 
       &:hover,
       &:focus {
@@ -148,10 +177,6 @@ nav-item-search {
       }
     }
   }
-
-  .media + .media {
-    //border-bottom-color:red;
-  }
 }
 
 // Accessible menu
@@ -185,4 +210,11 @@ nav-item-search {
 
 .has-sub .rotate {
   color: $color-p2;
+}
+
+/* Dark Mobile menu */
+@media (max-width: $screen-sm-max) {
+  .navigation-search {
+    background-color: $mobile-drawer;
+  }
 }

--- a/src/scss/colortheme/cs-search.scss
+++ b/src/scss/colortheme/cs-search.scss
@@ -12,6 +12,9 @@
   }
   .search-textfield {
     border-color: $gray-600 !important;
+    @media (max-width: $screen-sm-max) {
+      border-color: $white !important;
+    }
   }
 
   .gsc-search-button {
@@ -24,6 +27,22 @@
     }
     .ca-gov-icon-search {
       color: $white;
+    }
+    @media (max-width: $screen-sm-max) {
+      background-color: $white;
+      border-color: $white;
+      // border-left-color: $gray-700;
+      &:hover,
+      &:focus {
+        background-color: $gray-50;
+        border-color: $gray-50;
+        .ca-gov-icon-search {
+          color: $gray-900;
+        }
+      }
+      .ca-gov-icon-search {
+        color: $gray-700;
+      }
     }
   }
 

--- a/src/scss/colortheme/cs-site-header.scss
+++ b/src/scss/colortheme/cs-site-header.scss
@@ -2,11 +2,6 @@
    SITE HEADER
    /source/scss/colortheme/cs-site-header.scss
 ----------------------------------------- */
-@media (max-width: $screen-sm-max) {
-  header .section-default {
-    background-color: $color-s1 !important;
-  }
-}
 
 //
 // MOBILE CONTROLS

--- a/src/scss/colortheme/cs-site-header.scss
+++ b/src/scss/colortheme/cs-site-header.scss
@@ -1,0 +1,38 @@
+/* -----------------------------------------
+   SITE HEADER
+   /source/scss/colortheme/cs-site-header.scss
+----------------------------------------- */
+@media (max-width: $screen-sm-max) {
+  header .section-default {
+    background-color: $color-s1 !important;
+  }
+}
+
+//
+// MOBILE CONTROLS
+// --------------------------------------------------
+
+.toggle-menu span {
+  background-color: $color-p2;
+}
+.mobile-controls {
+  background: $white;
+}
+.mobile-control {
+  color: $mobile-controls;
+
+  a {
+    color: $mobile-controls;
+    text-decoration: none;
+  }
+
+  &.toggle-sub-nav {
+    color: $color-p2;
+    background-color: darken($sub-nav-bg, 2%);
+    &:hover,
+    &:focus {
+      outline: none;
+      background-color: $sub-nav-bg; // should be the same as sub-nav background
+    }
+  }
+}

--- a/src/scss/colortheme/delta-import.scss
+++ b/src/scss/colortheme/delta-import.scss
@@ -41,5 +41,6 @@
 @import "cs-blockquote.scss";
 @import "cs-executive-profile.scss";
 @import "cs-utility.scss";
+@import "cs-site-header.scss";
 
 @import "cs-high-contrast.scss"; // File should always be last

--- a/src/scss/colortheme/delta.scss
+++ b/src/scss/colortheme/delta.scss
@@ -98,3 +98,6 @@ $text-field-color: rgba(255, 255, 255, 0.8); // 80% white
 
 // UTILITY
 $utility-link-hover-color: #fff9eb;
+
+// MOBILE DRAWER BACKGROUND
+$mobile-drawer: $color-p3;

--- a/src/scss/colortheme/delta.scss
+++ b/src/scss/colortheme/delta.scss
@@ -101,3 +101,4 @@ $utility-link-hover-color: #fff9eb;
 
 // MOBILE DRAWER BACKGROUND
 $mobile-drawer: $color-p3;
+$mobile-drawer-active: lighten($color-p3, 7%);

--- a/src/scss/colortheme/eureka-import.scss
+++ b/src/scss/colortheme/eureka-import.scss
@@ -41,5 +41,6 @@
 @import "cs-blockquote.scss";
 @import "cs-executive-profile.scss";
 @import "cs-utility.scss";
+@import "cs-site-header.scss";
 
 @import "cs-high-contrast.scss"; // File should always be last

--- a/src/scss/colortheme/eureka.scss
+++ b/src/scss/colortheme/eureka.scss
@@ -94,3 +94,6 @@ $text-field-color: rgba(255, 255, 255, 0.8); // 80% white
 
 // UTILITY
 $utility-link-hover-color: lighten($color-p1, 35%);
+
+// MOBILE DRAWER BACKGROUND
+$mobile-drawer: $color-p3;

--- a/src/scss/colortheme/eureka.scss
+++ b/src/scss/colortheme/eureka.scss
@@ -97,3 +97,4 @@ $utility-link-hover-color: lighten($color-p1, 35%);
 
 // MOBILE DRAWER BACKGROUND
 $mobile-drawer: $color-p3;
+$mobile-drawer-active: lighten($color-p3, 7%);

--- a/src/scss/colortheme/mono-import.scss
+++ b/src/scss/colortheme/mono-import.scss
@@ -40,5 +40,6 @@
 @import "cs-blockquote.scss";
 @import "cs-executive-profile.scss";
 @import "cs-utility.scss";
+@import "cs-site-header.scss";
 
 @import "cs-high-contrast.scss"; // File should always be last

--- a/src/scss/colortheme/mono.scss
+++ b/src/scss/colortheme/mono.scss
@@ -94,3 +94,6 @@ $text-field-color: rgba(255, 255, 255, 0.8); // 80% white
 
 // UTILITY
 $utility-link-hover-color: lighten($color-p1, 35%);
+
+// MOBILE DRAWER BACKGROUND
+$mobile-drawer: $color-p3;

--- a/src/scss/colortheme/mono.scss
+++ b/src/scss/colortheme/mono.scss
@@ -97,3 +97,4 @@ $utility-link-hover-color: lighten($color-p1, 35%);
 
 // MOBILE DRAWER BACKGROUND
 $mobile-drawer: $color-p3;
+$mobile-drawer-active: lighten($color-p3, 7%);

--- a/src/scss/colortheme/oceanside-import.scss
+++ b/src/scss/colortheme/oceanside-import.scss
@@ -41,5 +41,6 @@
 @import "cs-blockquote.scss";
 @import "cs-executive-profile.scss";
 @import "cs-utility.scss";
+@import "cs-site-header.scss";
 
 @import "cs-high-contrast.scss"; // File should always be last

--- a/src/scss/colortheme/oceanside.scss
+++ b/src/scss/colortheme/oceanside.scss
@@ -95,3 +95,4 @@ $utility-link-hover-color: lighten($color-p1, 35%);
 
 // MOBILE DRAWER BACKGROUND
 $mobile-drawer: darken($color-p2, 7%);
+$mobile-drawer-active: $color-p2;

--- a/src/scss/colortheme/oceanside.scss
+++ b/src/scss/colortheme/oceanside.scss
@@ -92,3 +92,6 @@ $text-field-color: rgba(255, 255, 255, 0.8); // 80% white
 
 // UTILITY
 $utility-link-hover-color: lighten($color-p1, 35%);
+
+// MOBILE DRAWER BACKGROUND
+$mobile-drawer: darken($color-p2, 7%);

--- a/src/scss/colortheme/orangecounty-import.scss
+++ b/src/scss/colortheme/orangecounty-import.scss
@@ -41,5 +41,6 @@
 @import "cs-blockquote.scss";
 @import "cs-executive-profile.scss";
 @import "cs-utility.scss";
+@import "cs-site-header.scss";
 
 @import "cs-high-contrast.scss"; // File should always be last

--- a/src/scss/colortheme/orangecounty.scss
+++ b/src/scss/colortheme/orangecounty.scss
@@ -94,3 +94,6 @@ $text-field-color: rgba(255, 255, 255, 0.8); // 80% white
 
 // UTILITY
 $utility-link-hover-color: lighten($color-p1, 35%);
+
+// MOBILE DRAWER BACKGROUND
+$mobile-drawer: $color-p3;

--- a/src/scss/colortheme/orangecounty.scss
+++ b/src/scss/colortheme/orangecounty.scss
@@ -97,3 +97,4 @@ $utility-link-hover-color: lighten($color-p1, 35%);
 
 // MOBILE DRAWER BACKGROUND
 $mobile-drawer: $color-p3;
+$mobile-drawer-active: lighten($color-p3, 7%);

--- a/src/scss/colortheme/pasorobles-import.scss
+++ b/src/scss/colortheme/pasorobles-import.scss
@@ -41,5 +41,6 @@
 @import "cs-blockquote.scss";
 @import "cs-executive-profile.scss";
 @import "cs-utility.scss";
+@import "cs-site-header.scss";
 
 @import "cs-high-contrast.scss"; // File should always be last

--- a/src/scss/colortheme/pasorobles.scss
+++ b/src/scss/colortheme/pasorobles.scss
@@ -94,3 +94,6 @@ $text-field-color: rgba(255, 255, 255, 0.8); // 80% white
 
 // UTILITY
 $utility-link-hover-color: lighten($color-p1, 35%);
+
+// MOBILE DRAWER BACKGROUND
+$mobile-drawer: $color-p3;

--- a/src/scss/colortheme/pasorobles.scss
+++ b/src/scss/colortheme/pasorobles.scss
@@ -97,3 +97,4 @@ $utility-link-hover-color: lighten($color-p1, 35%);
 
 // MOBILE DRAWER BACKGROUND
 $mobile-drawer: $color-p3;
+$mobile-drawer-active: lighten($color-p3, 7%);

--- a/src/scss/colortheme/sacramento-import.scss
+++ b/src/scss/colortheme/sacramento-import.scss
@@ -42,5 +42,6 @@
 @import "cs-blockquote.scss";
 @import "cs-executive-profile.scss";
 @import "cs-utility.scss";
+@import "cs-site-header.scss";
 
 @import "cs-high-contrast.scss"; // File should always be last

--- a/src/scss/colortheme/sacramento.scss
+++ b/src/scss/colortheme/sacramento.scss
@@ -97,3 +97,4 @@ $utility-link-hover-color: lighten($color-p1, 35%);
 
 // MOBILE DRAWER BACKGROUND
 $mobile-drawer: $color-p2;
+$mobile-drawer-active: lighten($color-p2, 7%);

--- a/src/scss/colortheme/sacramento.scss
+++ b/src/scss/colortheme/sacramento.scss
@@ -94,3 +94,6 @@ $text-field-color: rgba(255, 255, 255, 0.8); // 80% white
 
 // UTILITY
 $utility-link-hover-color: lighten($color-p1, 35%);
+
+// MOBILE DRAWER BACKGROUND
+$mobile-drawer: $color-p2;

--- a/src/scss/colortheme/santabarbara-import.scss
+++ b/src/scss/colortheme/santabarbara-import.scss
@@ -41,5 +41,6 @@
 @import "cs-blockquote.scss";
 @import "cs-executive-profile.scss";
 @import "cs-utility.scss";
+@import "cs-site-header.scss";
 
 @import "cs-high-contrast.scss"; // File should always be last

--- a/src/scss/colortheme/santabarbara.scss
+++ b/src/scss/colortheme/santabarbara.scss
@@ -100,3 +100,4 @@ $utility-link-hover-color: lighten($color-p1, 35%);
 
 // MOBILE DRAWER BACKGROUND
 $mobile-drawer: $color-p3;
+$mobile-drawer-active: lighten($color-p3, 7%);

--- a/src/scss/colortheme/santabarbara.scss
+++ b/src/scss/colortheme/santabarbara.scss
@@ -97,3 +97,6 @@ $text-field-color: rgba(255, 255, 255, 0.8); // 80% white
 
 // UTILITY
 $utility-link-hover-color: lighten($color-p1, 35%);
+
+// MOBILE DRAWER BACKGROUND
+$mobile-drawer: $color-p3;

--- a/src/scss/colortheme/santacruz-import.scss
+++ b/src/scss/colortheme/santacruz-import.scss
@@ -41,5 +41,6 @@
 @import "cs-blockquote.scss";
 @import "cs-executive-profile.scss";
 @import "cs-utility.scss";
+@import "cs-site-header.scss";
 
 @import "cs-high-contrast.scss"; // File should always be last

--- a/src/scss/colortheme/santacruz.scss
+++ b/src/scss/colortheme/santacruz.scss
@@ -98,3 +98,4 @@ $utility-link-hover-color: #fff9eb;
 
 // MOBILE DRAWER BACKGROUND
 $mobile-drawer: $color-p3;
+$mobile-drawer-active: lighten($color-p3, 7%);

--- a/src/scss/colortheme/santacruz.scss
+++ b/src/scss/colortheme/santacruz.scss
@@ -95,3 +95,6 @@ $text-field-color: rgba(255, 255, 255, 0.8); // 80% white
 
 // UTILITY
 $utility-link-hover-color: #fff9eb;
+
+// MOBILE DRAWER BACKGROUND
+$mobile-drawer: $color-p3;

--- a/src/scss/colortheme/shasta-import.scss
+++ b/src/scss/colortheme/shasta-import.scss
@@ -41,5 +41,6 @@
 @import "cs-blockquote.scss";
 @import "cs-executive-profile.scss";
 @import "cs-utility.scss";
+@import "cs-site-header.scss";
 
 @import "cs-high-contrast.scss"; // File should always be last

--- a/src/scss/colortheme/shasta.scss
+++ b/src/scss/colortheme/shasta.scss
@@ -94,3 +94,6 @@ $text-field-color: rgba(255, 255, 255, 0.8); // 80% white
 
 // UTILITY
 $utility-link-hover-color: lighten($color-p1, 35%);
+
+// MOBILE DRAWER BACKGROUND
+$mobile-drawer: $color-p3;

--- a/src/scss/colortheme/shasta.scss
+++ b/src/scss/colortheme/shasta.scss
@@ -97,3 +97,4 @@ $utility-link-hover-color: lighten($color-p1, 35%);
 
 // MOBILE DRAWER BACKGROUND
 $mobile-drawer: $color-p3;
+$mobile-drawer-active: lighten($color-p3, 7%);

--- a/src/scss/colortheme/sierra-import.scss
+++ b/src/scss/colortheme/sierra-import.scss
@@ -41,5 +41,6 @@
 @import "cs-blockquote.scss";
 @import "cs-executive-profile.scss";
 @import "cs-utility.scss";
+@import "cs-site-header.scss";
 
 @import "cs-high-contrast.scss"; // File should always be last

--- a/src/scss/colortheme/sierra.scss
+++ b/src/scss/colortheme/sierra.scss
@@ -94,3 +94,6 @@ $text-field-color: rgba(255, 255, 255, 0.8); // 80% white
 
 // UTILITY
 $utility-link-hover-color: lighten($color-p1, 35%);
+
+// MOBILE DRAWER BACKGROUND
+$mobile-drawer: $color-p3;

--- a/src/scss/colortheme/sierra.scss
+++ b/src/scss/colortheme/sierra.scss
@@ -97,3 +97,4 @@ $utility-link-hover-color: lighten($color-p1, 35%);
 
 // MOBILE DRAWER BACKGROUND
 $mobile-drawer: $color-p3;
+$mobile-drawer-active: lighten($color-p3, 7%);

--- a/src/scss/colortheme/trinity-import.scss
+++ b/src/scss/colortheme/trinity-import.scss
@@ -41,5 +41,6 @@
 @import "cs-blockquote.scss";
 @import "cs-executive-profile.scss";
 @import "cs-utility.scss";
+@import "cs-site-header.scss";
 
 @import "cs-high-contrast.scss"; // File should always be last

--- a/src/scss/colortheme/trinity.scss
+++ b/src/scss/colortheme/trinity.scss
@@ -94,3 +94,6 @@ $text-field-color: rgba(255, 255, 255, 0.8); // 80% white
 
 // UTILITY
 $utility-link-hover-color: lighten($color-p1, 35%);
+
+// MOBILE DRAWER BACKGROUND
+$mobile-drawer: $color-p3;

--- a/src/scss/colortheme/trinity.scss
+++ b/src/scss/colortheme/trinity.scss
@@ -97,3 +97,4 @@ $utility-link-hover-color: lighten($color-p1, 35%);
 
 // MOBILE DRAWER BACKGROUND
 $mobile-drawer: $color-p3;
+$mobile-drawer-active: lighten($color-p3, 7%);


### PR DESCRIPTION
Updated mobile navigation based on latest figma prototypes.
- Added menu drawer with opacity overlay (the menu drawer overflow is scrollable, but the main content is not)
- Making sure only menu focusable elements are accessible when menu is activated (the other focusable elements in the rest of the body are not accessible when mobile menu is activated)
- Active search is visible in mobile menu drawer as soon as mobile menu is activated (there is no more mobile search button)
- Simplified the mobile branding and utility header based on figma prototype