### PR TITLE
fixing github code alert 37

### DIFF
--- a/src/js/cagov/accordion-list.js
+++ b/src/js/cagov/accordion-list.js
@@ -268,8 +268,6 @@
 
     // check to see if a trigger is disabled
     if (thisTrigger.getAttribute("aria-disabled") !== "true") {
-      let getID = thisTrigger.getAttribute("aria-controls");
-
       isCurrent(thisTrigger, true);
 
       if (thisTrigger.getAttribute("aria-expanded") === "true") {
@@ -279,21 +277,21 @@
         ariaExpanded(thisTrigger, true);
         ariaHidden(targetPanel, false);
 
-        if (doc.getElementById(thisAccordion).hasAttribute("data-constant")) {
+        if (doc.getElementById(thisAccordion).hasAttribute("data-constant"))
           ariaDisabled(thisTrigger, true);
-        }
       }
 
       if (
         doc.getElementById(thisAccordion).hasAttribute("data-constant") ||
         !doc.getElementById(thisAccordion).hasAttribute("data-multi")
       ) {
-        for (let i = 0; i < triggers.length; i++) {
-          if (thisTrigger !== triggers[i]) {
-            isCurrent(triggers[i], false);
-            getID = triggers[i].getAttribute("aria-controls");
-            ariaDisabled(triggers[i], false);
-            ariaExpanded(triggers[i], false);
+        // swap expanded when there is a single constant panel
+        for (let trigger of triggers) {
+          if (thisTrigger !== trigger) {
+            isCurrent(trigger, false);
+            const getID = trigger.getAttribute("aria-controls");
+            ariaDisabled(trigger, false);
+            ariaExpanded(trigger, false);
             ariaHidden(doc.getElementById(getID), true);
           }
         }


### PR DESCRIPTION
resolves https://github.com/Office-of-Digital-Services/California-State-Web-Template-Website/security/code-scanning/37

This is part of the "data-constant" accordion list mode where a panel is always open.  The sample code does not contain one like that, so you have to add a `data-constant="1"` to a accordion list to see it work.