### PR TITLE
Update google search result styles to use scss variables from the template theme

### DIFF
--- a/src/_includes/layouts/search.njk
+++ b/src/_includes/layouts/search.njk
@@ -2,32 +2,32 @@
 <html lang="en">
   <head>
     <title>{{ title }}</title>
-    <meta charset="utf-8" />
+    <meta charset="utf-8"/>
     {% if noindex %}
-    <meta name="robots" content="noindex" />
+      <meta name="robots" content="noindex"/>
     {% endif %}
-    <meta name="Author" content="State of California" />
-    <meta name="Description" content="State of California" />
-    <meta name="Keywords" content="California, government" />
-    <meta name="MobileOptimized" content="320" />
+    <meta name="Author" content="State of California"/>
+    <meta name="Description" content="State of California"/>
+    <meta name="Keywords" content="California, government"/>
+    <meta name="MobileOptimized" content="320"/>
     <meta
       name="viewport"
-      content="width=device-width, initial-scale=1.0, minimum-scale=1.0" />
+      content="width=device-width, initial-scale=1.0, minimum-scale=1.0"/>
     {% include "../head-js-css.njk" %}
     <!--hiding search link from page navigation sinse the search box is already open-->
     <style>
       #nav-item-search,
       .mobile-controls .toggle-search {
-          display: none;
+        display: none;
       }
 
       .mobile-controls .mobile-header-icons {
-          display: none;
+        display: none;
       }
       .search-textfield {
-       border-top-left-radius:5px;
-       border-bottom-left-radius:5px;
-       border:1px solid #72717c;
+        border-top-left-radius: 5px;
+        border-bottom-left-radius: 5px;
+        border: 1px solid #72717c;
       }
     </style>
   </head>
@@ -36,8 +36,13 @@
       <div id="skip-to-content">
         <a href="#main-content">Skip to Main Content</a>
       </div>
-      {% if alert %} {% include alert %} {% endif %} {% include
-      "../utility-header.njk" %} {% include "../site-header.njk" %} {% include
+      {% if alert %}
+        {% include alert %}
+      {% endif %}
+      {% include
+      "../utility-header.njk" %}
+      {% include "../site-header.njk" %}
+      {% include
       "../mobile-controls.njk" %}
 
       <div class="navigation-search full-width-nav container">
@@ -47,58 +52,64 @@
     </header>
 
     {%- block content %}
-    <div id="main-content" class="main-content">
-      <main class="main-primary" id="main">
-        <!--Search result section-->
-        <div class="section section-default">
-          <div class="container search-results-header">
-            <!--Uncomment if you prefer to use original google search box. Be advised that original custom search box is not meeting WCAG accessibility standards. -->
-            <!--<gcse:searchbox-only resultsUrl="/serp.html" enableAutoComplete="true"></gcse:searchbox-only>-->
+      <div id="main-content" class="main-content">
+        <main class="main-primary" id="main">
+          <!--Search result section-->
+          <div class="section section-default">
+            <div class="container search-results-header">
+              <!--Uncomment if you prefer to use original google search box. Be advised that original custom search box is not meeting WCAG accessibility standards. -->
+              <!--<gcse:searchbox-only resultsUrl="/serp.html" enableAutoComplete="true"></gcse:searchbox-only>-->
 
-            <form id="Search" class="d-flex" action="?">
-              <span class="sr-only" id="SearchInput">Custom Google Search</span>
-              <input
+              <form id="Search" class="d-flex" action="?">
+                <span class="sr-only" id="SearchInput">Custom Google Search</span>
+                <input
                 type="search"
                 id="q"
                 name="q"
                 aria-labelledby="SearchInput"
                 placeholder="Search this website"
                 class="search-textfield height-40"
-                style="width:95%" />
-              <button
+                style="width:95%"/>
+                <button
                 type="submit"
                 class="gsc-search-button width-60 height-40 color-white border-0 bg-gray-600 bg-gray-800-hover">
-                <span class="ca-gov-icon-search" aria-hidden="true"></span>
-                <span class="sr-only">Submit</span>
-              </button>
-            </form>
+                  <span class="ca-gov-icon-search" aria-hidden="true"></span>
+                  <span class="sr-only">Submit</span>
+                </button>
+              </form>
+            </div>
           </div>
-        </div>
-        <div class="section">
-          <div class="container">
-            <gcse:searchresults-only></gcse:searchresults-only>
-            <!-- <script src='//www.google.com/jsapi' type='text/javascript'></script> -->
+          <div class="section">
+            <div class="container">
+              <gcse:searchresults-only></gcse:searchresults-only>
+              <!-- <script src='//www.google.com/jsapi' type='text/javascript'></script> -->
 
-            {{ content | safe }}
+              {{ content | safe }}
+            </div>
           </div>
-        </div>
-      </main>
-    </div>
-    {% endblock -%} {%- include "../global-footer.njk" -%} {%- include
+        </main>
+      </div>
+    {% endblock -%}
+    {%- include "../global-footer.njk" -%}
+    {%- include
     "../scripts.njk" %}
 
     <script>
       // Search ID
-      var cx = '05e92f21f387b4800';// Update this value with your search engine unique ID. Submit a request to the CDT Service Desk if you don't already know your unique search engine ID.
+      var cx = '05e92f21f387b4800'; // Update this value with your search engine unique ID. Submit a request to the CDT Service Desk if you don't already know your unique search engine ID.
       var gcse = document.createElement('script');
       gcse.type = 'text/javascript';
       gcse.async = true;
       gcse.src = 'https://cse.google.com/cse.js?cx=' + cx;
       var s = document.getElementsByTagName('script');
-      s[s.length - 1].parentNode.insertBefore(gcse, s[s.length - 1]);
+      s[s.length - 1]
+        .parentNode
+        .insertBefore(gcse, s[s.length - 1]);
 
       // extracting search query from the url parameter and applying it to the searchbox
-      document.querySelector('input[name=q]').value = new URLSearchParams(window.location.search).get("q");
+      document
+        .querySelector('input[name=q]')
+        .value = new URLSearchParams(window.location.search).get("q");
     </script>
   </body>
 </html>

--- a/src/scss/cagov/search-google-cse.scss
+++ b/src/scss/cagov/search-google-cse.scss
@@ -21,3 +21,33 @@
   float: left;
   margin-right: calc($grid-gutter-width / 2);
 }
+
+.gs-result {
+  a.gs-title,
+  a.gs-title b {
+    color: $color-p2 !important;
+  }
+  .gsc-url-top {
+    .gs-visibleUrl-breadcrumb span {
+      color: var(--bs-gray-600, #6c757d) !important;
+    }
+  }
+  .gs-snippet {
+    color: $text-color !important;
+  }
+}
+
+.gsc-cursor-box {
+  .gsc-cursor {
+    .gsc-cursor-page {
+      color: $color-p3 !important;
+    }
+    .gsc-cursor-current-page {
+      color: $color-p3 !important;
+    }
+  }
+}
+
+.gcsc-find-more-on-google {
+  color: $color-p2 !important;
+}

--- a/src/scss/cagov/search-google-cse.scss
+++ b/src/scss/cagov/search-google-cse.scss
@@ -29,7 +29,7 @@
   }
   .gsc-url-top {
     .gs-visibleUrl-breadcrumb span {
-      color: var(--bs-gray-600, #6c757d) !important;
+      color: $gray-600 !important;
     }
   }
   .gs-snippet {


### PR DESCRIPTION
#1404 

Update overrides the following in the google search results:
 - title
 - breadcrumb
 - description
 - page cursor
 - more from google

Currently the style is either set by default from google (which has color contrast issues) or specifically using the search console theme settings. The proposed change uses the scss variables from the state template color themes to update and manage the colors of the results. 