### PR TITLE
increased scroll margin for target elements to 150px

### DIFF
--- a/src/scss/cagov/fixed-header.scss
+++ b/src/scss/cagov/fixed-header.scss
@@ -70,5 +70,8 @@
 }
 
 h2 {
-  scroll-margin-top: 150px;
+  scroll-margin-top: 100px;
+  @media (min-width: $screen-md-min) {
+    scroll-margin-top: 150px;
+  }
 }

--- a/src/scss/cagov/fixed-header.scss
+++ b/src/scss/cagov/fixed-header.scss
@@ -70,7 +70,7 @@
 }
 
 h2 {
-  scroll-margin-top: 100px;
+  scroll-margin-top: 75px;
   @media (min-width: $screen-md-min) {
     scroll-margin-top: 150px;
   }

--- a/src/scss/cagov/fixed-header.scss
+++ b/src/scss/cagov/fixed-header.scss
@@ -70,5 +70,5 @@
 }
 
 h2 {
-  scroll-margin-top: 50px;
+  scroll-margin-top: 150px;
 }


### PR DESCRIPTION
When clicking the "on this page" links, the sticky header covers the target heading text. It appears to be a sitewide issue. Increasing this from 50 to 150 seems to fix it