### PR TITLE
adding a css rule for larger footer icon

### DIFF
--- a/src/scss/cagov/global-footer.scss
+++ b/src/scss/cagov/global-footer.scss
@@ -17,6 +17,11 @@
     img {
       height: 1.7rem;
     }
+
+    .ca-gov-logo-svg {
+      height: 1.7rem;
+      width: auto;
+    }
   }
 
   .footer-links {


### PR DESCRIPTION
Didn't notice that the footer icon was supposed to be larger, restoring the size.