### PR TITLE
a11y- adding footer context for screen readers

### DIFF
--- a/src/_includes/modules/site-footer.html
+++ b/src/_includes/modules/site-footer.html
@@ -9,22 +9,22 @@
           State Web Template
         </div>
         <a href="/about.html" class="d-block no-underline m-y font-size-16">
-          About
+          About <span class="sr-only">this website</span>
         </a>
         <a
           href="/contact-us.html"
           class="d-block no-underline m-y font-size-16">
-          Contact us
+          Contact us <span class="sr-only">regarding this website</span>
         </a>
         <a
           href="https://airtable.com/shro9V6ry2Cf4mpgG"
           class="d-block no-underline m-y font-size-16">
-          Give feedback
+          Give feedback <span class="sr-only">regarding this website</span>
         </a>
         <a
           href="/accessibility.html"
           class="d-block no-underline m-y font-size-16">
-          Accessibility <span class="sr-only">compliance</span>
+          Accessibility <span class="sr-only">compliance for this website</span>
         </a>
       </div>
       <div class="col-md-4">


### PR DESCRIPTION
Adding extended context for the small footer icons to reduce screen reader confusion with other page links (mainly accessibility)