### PR TITLE
HOTFIX - new state analytics

### DIFF
--- a/src/_includes/analytics.njk
+++ b/src/_includes/analytics.njk
@@ -1,12 +1,19 @@
 <!-- BEGIN Google Tag Manager -->
 <script>
-  //Replace this with your GTM tag from https://tagmanager.google.com
-  const gtmTag = "GTM-PWPX7KD";
+  //The GA4 Measurement ID that this website should use for website analytics
+  //*** BEGIN STATE TEMPLATE CHANGE REQUESTED
+  const yourGA4MeasurementId = "G-XFPJTRCEF6"; //Set to the default GA4 Measurement ID (G-75V2BNQ3DR), please change it to the one for your organization.
+  //*** END STATE TEMPLATE CHANGE REQUESTED
 
+  //Keep this tag mananger code as is, it helps collect data for ALL ca.gov sites
+  const stateGTMAccount = "GTM-5233GKC"; //GTM-5233GKC, all ca.gov + State Template Version 6.1.2
+
+  //Support code to make this work, just leave this as is
   (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
   new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
   j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-  })(window,document,'script','dataLayer',gtmTag);
+  (function(){dataLayer.push(arguments)})('config',yourGA4MeasurementId);
+  })(window,document,'script','dataLayer',stateGTMAccount);
 </script>
 <!-- END Google Tag Manager -->


### PR DESCRIPTION
- Putting out a new analytics structure that other sites can use and change.
- Includes new statewide GTM - GTM-5233GKC - that records to applicable state accounts
  - G-69TD0KNT0F - Statewide
  - G-YV8TCM9SDY - New Template Version Tracker for 6.1
- Includes new GA4 account just for template.webstandards.ca.gov
  - G-XFPJTRCEF6
- Mentions the "bad boy" default GA4 account that will be attached to new template releases (not this site)
  - G-75V2BNQ3DR
- All runs efficiently using GTM code 