### PR TITLE
Hotfix - Analytics preconnect

### DIFF
--- a/src/_includes/analytics.njk
+++ b/src/_includes/analytics.njk
@@ -1,4 +1,6 @@
 <!-- BEGIN Google Tag Manager -->
+<link rel="preconnect" href="https://www.googletagmanager.com" />
+<link rel="preconnect" href="https://www.google-analytics.com" />
 <script>
   //The GA4 Measurement ID that this website should use for website analytics
   //*** BEGIN STATE TEMPLATE CHANGE REQUESTED


### PR DESCRIPTION
Recommended for Google analytics to enable preconnect to speed up requests for 3rd party data.