### PR TITLE
SEO - adding nocanonical for dynamic links

### DIFF
--- a/pages/sample/colortheme.html
+++ b/pages/sample/colortheme.html
@@ -3,6 +3,7 @@ title: Color Theme
 landing: Visual design
 layout: landing.njk
 permalink: "visual-design/color/"
+nocanonical: true
 ---
 
 <div class="container p-t-md">

--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -22,9 +22,12 @@
     <meta
       name="description"
       content="Version 6 of the State Web Template is California's latest web design standard." />
+    {%- if not nocanonical %}
     <!-- Canonical link, improves SEO -->
     <link href="https://template.webstandards.ca.gov{{
     ("/"+permalink).replace("//"," /") if permalink }}" rel="canonical">
+    <!-- END Canonical link -->
+    {% endif -%}
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://template.webstandards.ca.gov/" />


### PR DESCRIPTION
Color theme pages are dynamic based on querystring, so they can't be set as the same canonical.
option to disable cononical by page