### PR TITLE
SEO - more redirects

### DIFF
--- a/pages/contact-us-form.html
+++ b/pages/contact-us-form.html
@@ -261,7 +261,11 @@ permalink: "contact-us.html"
   class="hidden"
   data-bs-toggle="modal"
   data-bs-target="#modalResponse"></button>
-<a href="contact-us-thankyou.html" id="urlThankyou" class="hidden"></a>
+<a
+  href="contact-us-thankyou.html"
+  id="urlThankyou"
+  class="hidden"
+  rel="noindex"></a>
 
 <script>
   const serviceUrl = "https://api.template.webstandards.ca.gov/api/air-table";

--- a/pages/sample/article-sample.html
+++ b/pages/sample/article-sample.html
@@ -13,13 +13,17 @@ permalink: "/patterns/article-sample.html"
       </a>
     </li>
     <li>
-      <a href="/patterns/newsroom-sample.html" title="Newsroom landing page">
+      <a
+        href="/patterns/newsroom-sample.html"
+        title="Newsroom landing page"
+        rel="noindex">
         Newsroom
       </a>
     </li>
     <li>
       <a
         href="/patterns/list-of-articles-or-content-sample.html"
+        rel="noindex"
         title="List of articles landing page">
         Press releases
       </a>
@@ -34,6 +38,7 @@ permalink: "/patterns/article-sample.html"
         <li>
           <a
             href="/patterns/list-of-articles-or-content-sample.html"
+            rel="noindex"
             class="landing back">
             Press releases
           </a>

--- a/pages/sample/article.html
+++ b/pages/sample/article.html
@@ -66,6 +66,7 @@ permalink: "/patterns/article.html"
 
         <a
           href="/patterns/article-sample.html"
+          rel="noindex"
           class="btn btn-outline-primary mb-4"
           target="_blank">
           Live example in new tab

--- a/pages/sample/list-of-articles-or-content-sample.html
+++ b/pages/sample/list-of-articles-or-content-sample.html
@@ -13,7 +13,10 @@ permalink: "/patterns/list-of-articles-or-content-sample.html"
       </a>
     </li>
     <li>
-      <a href="/patterns/newsroom-sample.html" title="Newsroom page">
+      <a
+        href="/patterns/newsroom-sample.html"
+        title="Newsroom page"
+        rel="noindex">
         Newsroom
       </a>
     </li>
@@ -26,7 +29,9 @@ permalink: "/patterns/list-of-articles-or-content-sample.html"
     <nav aria-label="list navigation" class="side-navigation">
       <ul>
         <li>
-          <a href="/patterns/newsroom-sample.html" class="landing">Newsroom</a>
+          <a href="/patterns/newsroom-sample.html" rel="noindex" class="landing"
+            >Newsroom</a
+          >
         </li>
         <li><a href="javascript:;" aria-disabled="true">News articles</a></li>
         <li>

--- a/pages/sample/list-of-articles-or-content.html
+++ b/pages/sample/list-of-articles-or-content.html
@@ -85,6 +85,7 @@ permalink: "/patterns/list-of-articles-or-content.html"
 
         <a
           href="/patterns/list-of-articles-or-content-sample.html"
+          rel="noindex"
           class="btn btn-outline-primary mb-4"
           target="_blank">
           Live example in new tab

--- a/pages/sample/newsroom-sampe-featured.html
+++ b/pages/sample/newsroom-sampe-featured.html
@@ -19,7 +19,9 @@ permalink: "/patterns/newsroom-featured-banner.html"
         <li><a href="javascript:;" class="landing active">Newsroom</a></li>
         <li><a href="javascript:;" aria-disabled="true">News articles</a></li>
         <li>
-          <a href="/patterns/list-of-articles-or-content-sample.html">
+          <a
+            href="/patterns/list-of-articles-or-content-sample.html"
+            rel="noindex">
             Press releases
           </a>
         </li>

--- a/pages/sample/newsroom-sampe.html
+++ b/pages/sample/newsroom-sampe.html
@@ -19,7 +19,9 @@ permalink: "/patterns/newsroom-sample.html"
         <li><a href="javascript:;" class="landing active">Newsroom</a></li>
         <li><a href="javascript:;" aria-disabled="true">News articles</a></li>
         <li>
-          <a href="/patterns/list-of-articles-or-content-sample.html">
+          <a
+            href="/patterns/list-of-articles-or-content-sample.html"
+            rel="noindex">
             Press releases
           </a>
         </li>

--- a/pages/sample/newsroom.html
+++ b/pages/sample/newsroom.html
@@ -78,6 +78,7 @@ permalink: "patterns/newsroom.html"
 
         <a
           href="/patterns/newsroom-sample.html"
+          rel="noindex"
           class="btn btn-outline-primary mb-4"
           target="_blank"
           title="Featured images news live example">

--- a/pages/sample/newsroom.html
+++ b/pages/sample/newsroom.html
@@ -176,6 +176,7 @@ permalink: "patterns/newsroom.html"
         <a
           href="/patterns/newsroom-featured-banner.html"
           class="btn btn-outline-primary mb-4"
+          rel="noindex"
           target="_blank">
           Live example in new tab
           <span class="ca-gov-icon-arrow-next" aria-hidden="true"></span>

--- a/pages/sample/side-navigation-sample-level2.html
+++ b/pages/sample/side-navigation-sample-level2.html
@@ -8,13 +8,17 @@ permalink: "/components/side-navigation-sample-level2.html"
 <nav aria-label="Breadcrumb">
   <ol class="breadcrumb">
     <li>
-      <a href="/components/side-navigation-sample.html" title="Home page">
+      <a
+        href="/components/side-navigation-sample.html"
+        rel="noindex"
+        title="Home page">
         Home
       </a>
     </li>
     <li>
       <a
         href="/components/side-navigation-sample.html"
+        rel="noindex"
         title="Examples landing page">
         Type of parties
       </a>
@@ -30,6 +34,7 @@ permalink: "/components/side-navigation-sample-level2.html"
         <li>
           <a
             href="/components/side-navigation-sample.html"
+            rel="noindex"
             class="landing back">
             Types of parties
           </a>
@@ -37,6 +42,7 @@ permalink: "/components/side-navigation-sample-level2.html"
         <li>
           <a
             href="/components/side-navigation-sample-level2.html"
+            rel="noindex"
             class="active">
             Birthday
           </a>
@@ -47,7 +53,9 @@ permalink: "/components/side-navigation-sample-level2.html"
               </a>
             </li>
             <li>
-              <a href="/components/side-navigation-sample-level3.html">
+              <a
+                href="/components/side-navigation-sample-level3.html"
+                rel="noindex">
                 Planning
               </a>
             </li>
@@ -115,6 +123,7 @@ permalink: "/components/side-navigation-sample-level2.html"
       <div class="col-lg-4">
         <a
           href="/components/side-navigation-sample-level3.html"
+          rel="noindex"
           class="no-underline d-block color-gray-dark brd-gray-light brd-solid-1 rounded-5 h-100 transition-0_3 shadow2-hover color-primary color-primary-hover"
           title="Planning">
           <div class="p-a">

--- a/pages/sample/side-navigation-sample-level3.html
+++ b/pages/sample/side-navigation-sample-level3.html
@@ -8,13 +8,17 @@ permalink: "/components/side-navigation-sample-level3.html"
 <nav aria-label="Breadcrumb">
   <ol class="breadcrumb">
     <li>
-      <a href="/components/side-navigation-sample.html" title="Home page">
+      <a
+        href="/components/side-navigation-sample.html"
+        rel="noindex"
+        title="Home page">
         Home
       </a>
     </li>
     <li>
       <a
         href="/components/side-navigation-sample.html"
+        rel="noindex"
         title="Type of parties landing page">
         Type of parties
       </a>
@@ -22,6 +26,7 @@ permalink: "/components/side-navigation-sample-level3.html"
     <li>
       <a
         href="/components/side-navigation-sample-level2.html"
+        rel="noindex"
         title="Birthday party landing page">
         Birthday party
       </a>
@@ -37,6 +42,7 @@ permalink: "/components/side-navigation-sample-level3.html"
         <li>
           <a
             href="/components/side-navigation-sample-level2.html"
+            rel="noindex"
             class="landing back">
             Birthday
           </a>
@@ -49,6 +55,7 @@ permalink: "/components/side-navigation-sample-level3.html"
         <li>
           <a
             href="/components/side-navigation-sample-level3.html"
+            rel="noindex"
             class="active">
             Planning
           </a>
@@ -74,7 +81,9 @@ permalink: "/components/side-navigation-sample-level3.html"
               </a>
             </li>
             <li>
-              <a href="/components/side-navigation-sample-level4.html">
+              <a
+                href="/components/side-navigation-sample-level4.html"
+                rel="noindex">
                 Food and drinks
               </a>
             </li>
@@ -172,6 +181,7 @@ permalink: "/components/side-navigation-sample-level3.html"
       <div class="col-lg-4">
         <a
           href="/components/side-navigation-sample-level4.html"
+          rel="noindex"
           class="no-underline d-block color-gray-dark brd-gray-light brd-solid-1 rounded-5 h-100 transition-0_3 shadow2-hover color-primary color-primary-hover"
           title="Planning">
           <div class="p-a">

--- a/pages/sample/side-navigation-sample-level4.html
+++ b/pages/sample/side-navigation-sample-level4.html
@@ -89,7 +89,9 @@ permalink: "/components/side-navigation-sample-level4.html"
               </a>
             </li>
             <li>
-              <a href="/components/side-navigation-sample-level5.html">
+              <a
+                href="/components/side-navigation-sample-level5.html"
+                rel="noindex">
                 Dessert
               </a>
             </li>
@@ -169,6 +171,7 @@ permalink: "/components/side-navigation-sample-level4.html"
       <div class="col-lg-4">
         <a
           href="/components/side-navigation-sample-level5.html"
+          rel="noindex"
           class="no-underline d-block color-gray-dark brd-gray-light brd-solid-1 rounded-5 h-100 transition-0_3 shadow2-hover color-primary color-primary-hover"
           title="Planning">
           <div class="p-a">

--- a/pages/sample/side-navigation-sample-level4.html
+++ b/pages/sample/side-navigation-sample-level4.html
@@ -8,13 +8,17 @@ permalink: "/components/side-navigation-sample-level4.html"
 <nav aria-label="Breadcrumb">
   <ol class="breadcrumb">
     <li>
-      <a href="/components/side-navigation-sample.html" title="Home page">
+      <a
+        href="/components/side-navigation-sample.html"
+        rel="noindex"
+        title="Home page">
         Home
       </a>
     </li>
     <li>
       <a
         href="/components/side-navigation-sample.html"
+        rel="noindex"
         title="Type of parties landing page">
         Type of parties
       </a>
@@ -22,6 +26,7 @@ permalink: "/components/side-navigation-sample-level4.html"
     <li>
       <a
         href="/components/side-navigation-sample-level2.html"
+        rel="noindex"
         title="Birthday party landing page">
         Birthday party
       </a>
@@ -29,6 +34,7 @@ permalink: "/components/side-navigation-sample-level4.html"
     <li>
       <a
         href="/components/side-navigation-sample-level3.html"
+        rel="noindex"
         title="Planning landing page">
         Planning
       </a>
@@ -44,6 +50,7 @@ permalink: "/components/side-navigation-sample-level4.html"
         <li>
           <a
             href="/components/side-navigation-sample-level3.html"
+            rel="noindex"
             class="landing back">
             Planning
           </a>
@@ -69,6 +76,7 @@ permalink: "/components/side-navigation-sample-level4.html"
         <li>
           <a
             href="/components/side-navigation-sample-level4.html"
+            rel="noindex"
             class="active">
             Food and drinks
           </a>

--- a/pages/sample/side-navigation-sample-level5.html
+++ b/pages/sample/side-navigation-sample-level5.html
@@ -73,6 +73,7 @@ permalink: "/components/side-navigation-sample-level5.html"
         <li>
           <a
             href="/components/side-navigation-sample-level5.html"
+            rel="noindex"
             class="active">
             Dessert
           </a>

--- a/pages/sample/side-navigation-sample-level5.html
+++ b/pages/sample/side-navigation-sample-level5.html
@@ -8,13 +8,17 @@ permalink: "/components/side-navigation-sample-level5.html"
 <nav aria-label="Breadcrumb">
   <ol class="breadcrumb">
     <li>
-      <a href="/components/side-navigation-sample.html" title="Home page">
+      <a
+        href="/components/side-navigation-sample.html"
+        rel="noindex"
+        title="Home page">
         Home
       </a>
     </li>
     <li>
       <a
         href="/components/side-navigation-sample.html"
+        rel="noindex"
         title="Type of parties landing page">
         Type of parties
       </a>
@@ -22,6 +26,7 @@ permalink: "/components/side-navigation-sample-level5.html"
     <li>
       <a
         href="/components/side-navigation-sample-level2.html"
+        rel="noindex"
         title="Birthday party landing page">
         Birthday party
       </a>
@@ -29,6 +34,7 @@ permalink: "/components/side-navigation-sample-level5.html"
     <li>
       <a
         href="/components/side-navigation-sample-level3.html"
+        rel="noindex"
         title="Planning landing page">
         Planning
       </a>
@@ -36,6 +42,7 @@ permalink: "/components/side-navigation-sample-level5.html"
     <li>
       <a
         href="/components/side-navigation-sample-level4.html"
+        rel="noindex"
         title="Food and drinks landing page">
         Food and drinks
       </a>
@@ -51,6 +58,7 @@ permalink: "/components/side-navigation-sample-level5.html"
         <li>
           <a
             href="/components/side-navigation-sample-level4.html"
+            rel="noindex"
             class="landing back">
             Food and drinks
           </a>
@@ -79,7 +87,9 @@ permalink: "/components/side-navigation-sample-level5.html"
           </a>
           <ul>
             <li>
-              <a href="/components/side-navigation-sample-level6.html">
+              <a
+                href="/components/side-navigation-sample-level6.html"
+                rel="noindex">
                 Birthday cake
               </a>
             </li>
@@ -117,6 +127,7 @@ permalink: "/components/side-navigation-sample-level5.html"
       <div class="col-lg-4">
         <a
           href="/components/side-navigation-sample-level6.html"
+          rel="noindex"
           class="no-underline d-block color-gray-dark brd-gray-light brd-solid-1 rounded-5 h-100 transition-0_3 shadow2-hover color-primary color-primary-hover"
           title="Planning"
           aria-disabled="true">

--- a/pages/sample/side-navigation-sample-level6.html
+++ b/pages/sample/side-navigation-sample-level6.html
@@ -8,13 +8,17 @@ permalink: "/components/side-navigation-sample-level6.html"
 <nav aria-label="Breadcrumb">
   <ol class="breadcrumb">
     <li>
-      <a href="/components/side-navigation-sample.html" title="Home page">
+      <a
+        href="/components/side-navigation-sample.html"
+        rel="noindex"
+        title="Home page">
         Home
       </a>
     </li>
     <li>
       <a
         href="/components/side-navigation-sample.html"
+        rel="noindex"
         title="Type of parties landing page">
         Type of parties
       </a>
@@ -22,6 +26,7 @@ permalink: "/components/side-navigation-sample-level6.html"
     <li>
       <a
         href="/components/side-navigation-sample-level2.html"
+        rel="noindex"
         title="Birthday party landing page">
         Birthday party
       </a>
@@ -29,6 +34,7 @@ permalink: "/components/side-navigation-sample-level6.html"
     <li>
       <a
         href="/components/side-navigation-sample-level3.html"
+        rel="noindex"
         title="Planning landing page">
         Planning
       </a>
@@ -36,6 +42,7 @@ permalink: "/components/side-navigation-sample-level6.html"
     <li>
       <a
         href="/components/side-navigation-sample-level4.html"
+        rel="noindex"
         title="Food and drinks landing page">
         Food and drinks
       </a>
@@ -68,6 +75,7 @@ permalink: "/components/side-navigation-sample-level6.html"
         <li>
           <a
             href="/components/side-navigation-sample-level6.html"
+            rel="noindex"
             class="active">
             Birthday cake
           </a>

--- a/pages/sample/side-navigation-sample-level6.html
+++ b/pages/sample/side-navigation-sample-level6.html
@@ -43,6 +43,7 @@ permalink: "/components/side-navigation-sample-level6.html"
     <li>
       <a
         href="/components/side-navigation-sample-level5.html"
+        rel="noindex"
         title="Dessert landing page">
         Dessert
       </a>
@@ -58,6 +59,7 @@ permalink: "/components/side-navigation-sample-level6.html"
         <li>
           <a
             href="/components/side-navigation-sample-level5.html"
+            rel="noindex"
             class="landing back">
             Dessert
           </a>

--- a/pages/sample/side-navigation-sample.html
+++ b/pages/sample/side-navigation-sample.html
@@ -8,7 +8,10 @@ permalink: "/components/side-navigation-sample.html"
 <nav aria-label="Breadcrumb">
   <ol class="breadcrumb">
     <li>
-      <a href="/components/side-navigation-sample.html" title="Home page">
+      <a
+        href="/components/side-navigation-sample.html"
+        rel="noindex"
+        title="Home page">
         Home
       </a>
     </li>
@@ -24,7 +27,9 @@ permalink: "/components/side-navigation-sample.html"
           <a href="javascript:;" class="landing active">Types of parties</a>
         </li>
         <li>
-          <a href="/components/side-navigation-sample-level2.html">Birthday</a>
+          <a href="/components/side-navigation-sample-level2.html" rel="noindex"
+            >Birthday</a
+          >
         </li>
         <li>
           <a href="javascript:;" class="gray-200" aria-disabled="true">
@@ -63,6 +68,7 @@ permalink: "/components/side-navigation-sample.html"
       <div class="col-lg-4">
         <a
           href="/components/side-navigation-sample-level2.html"
+          rel="noindex"
           class="no-underline d-block color-gray-dark brd-gray-light brd-solid-1 rounded-5 h-100 transition-0_3 shadow2-hover color-primary color-primary-hover"
           title="Birthday">
           <div class="p-a">

--- a/pages/sample/side-navigation.html
+++ b/pages/sample/side-navigation.html
@@ -134,7 +134,10 @@ permalink: "/components/side-navigation.html"
 
 <p class="m-b-lg">
   For an example that has 6 levels, review our
-  <a href="/components/side-navigation-sample.html" target="_blank">
+  <a
+    href="/components/side-navigation-sample.html"
+    rel="noindex"
+    target="_blank">
     live example.
   </a>
 </p>
@@ -230,6 +233,7 @@ permalink: "/components/side-navigation.html"
           </div>
           <a
             href="/components/side-navigation-sample.html"
+            rel="noindex"
             class="btn btn-outline-primary mb-4"
             target="_blank">
             Live example in new tab

--- a/src/_data/websiteRedirects.csv
+++ b/src/_data/websiteRedirects.csv
@@ -2,6 +2,7 @@ original_url,replacement_url
 /business-profile.html,
 /components/accordions.html,/components/accordion.html
 /components/buttons.html,/components/button.html
+/components/horizontal-rule.html,/components/horizontal-separator.html
 /contact.html,/contact-us.html
 /css/colortheme-/,/visual-design/color/
 /general-landing.html,

--- a/src/_data/websiteRedirects.csv
+++ b/src/_data/websiteRedirects.csv
@@ -5,6 +5,7 @@ original_url,replacement_url
 /contact.html,/contact-us.html
 /css/colortheme-/,/visual-design/color/
 /general-landing.html,
+/get-started/,/get-started.html
 /get-started/index.html,/get-started.html
 /Getting-started.html,/get-started.html
 /get-started/css-classes-shortcuts/index.html,/get-started/css-classes-shortcuts/

--- a/src/_includes/modules/navigation-sample-site.njk
+++ b/src/_includes/modules/navigation-sample-site.njk
@@ -9,6 +9,7 @@
     <li class="nav-item" role="presentation">
       <a
         href="/components/side-navigation-sample.html"
+        rel="noindex"
         class="first-level-link active">
         Types of parties
       </a>

--- a/src/_includes/modules/site-header-sample-site-news.njk
+++ b/src/_includes/modules/site-header-sample-site-news.njk
@@ -2,10 +2,10 @@
 <div class="section-default">
   <div class="branding">
     <div class="header-organization-banner">
-      <a href="/patterns/newsroom-sample.html">
+      <a href="/patterns/newsroom-sample.html" rel="noindex">
         <div class="logo-assets">
           <img
-            src="/images/sample//images/sample-logo.png"
+            src="/images/sample-logo.png"
             class="logo-img"
             alt="Sample site Logo" />
           <div class="logo-text">

--- a/src/_includes/modules/site-header-sample-site.njk
+++ b/src/_includes/modules/site-header-sample-site.njk
@@ -2,7 +2,7 @@
 <div class="section-default">
   <div class="branding">
     <div class="header-organization-banner">
-      <a href="/components/side-navigation-sample.html">
+      <a href="/components/side-navigation-sample.html" rel="noindex">
         <div class="logo-assets">
           <img
             src="/images/icons/balloons.svg"


### PR DESCRIPTION
- adding `rel="noindex"` on links that go to pages with no index (Sample pages).  SEO doesn't like wasting time following links to "noindex" pages.
- More redirects noticed