### PR TITLE
fixing default url for colors

### DIFF
--- a/pages/sample/colortheme.html
+++ b/pages/sample/colortheme.html
@@ -404,6 +404,11 @@ nocanonical: true
 
   if (!queryString || !themeData[queryString]) {
    queryString = "delta"; // set a default theme
+
+   if (window.history.replaceState) {
+    // replacing the querystring so that SEO matches
+    window.history.replaceState(null, document.title, location.origin+location.pathname+"?"+queryString);
+   }
   }
 
   // insert new color theme css


### PR DESCRIPTION
This should remove

https://template.webstandards.ca.gov/visual-design/color/

and replace it with

https://template.webstandards.ca.gov/visual-design/color/?delta