### PR TITLE
removing font-only from css page after 6.0.7

### DIFF
--- a/pages/cdn.html
+++ b/pages/cdn.html
@@ -104,8 +104,6 @@ permalink: "cdn.html"
       <pre>
   <code class="overflow-auto">https://california.azureedge.net/cdt/statetemplate/6.2.1/css/cagov.core.css
   https://california.azureedge.net/cdt/statetemplate/6.2.1/css/cagov.core.min.css
-  https://california.azureedge.net/cdt/statetemplate/6.2.1/css/cagov.font-only.css
-  https://california.azureedge.net/cdt/statetemplate/6.2.1/css/cagov.font-only.min.css
   https://california.azureedge.net/cdt/statetemplate/6.2.1/css/colortheme-delta.css
   https://california.azureedge.net/cdt/statetemplate/6.2.1/css/colortheme-delta.min.css
   https://california.azureedge.net/cdt/statetemplate/6.2.1/css/colortheme-eureka.css
@@ -144,8 +142,6 @@ permalink: "cdn.html"
       <pre>
   <code class="overflow-auto">https://california.azureedge.net/cdt/statetemplate/6.2.0/css/cagov.core.css
   https://california.azureedge.net/cdt/statetemplate/6.2.0/css/cagov.core.min.css
-  https://california.azureedge.net/cdt/statetemplate/6.2.0/css/cagov.font-only.css
-  https://california.azureedge.net/cdt/statetemplate/6.2.0/css/cagov.font-only.min.css
   https://california.azureedge.net/cdt/statetemplate/6.2.0/css/colortheme-delta.css
   https://california.azureedge.net/cdt/statetemplate/6.2.0/css/colortheme-delta.min.css
   https://california.azureedge.net/cdt/statetemplate/6.2.0/css/colortheme-eureka.css
@@ -183,8 +179,6 @@ permalink: "cdn.html"
       <pre>
   <code class="overflow-auto">https://california.azureedge.net/cdt/statetemplate/6.1.2/css/cagov.core.css
   https://california.azureedge.net/cdt/statetemplate/6.1.2/css/cagov.core.min.css
-  https://california.azureedge.net/cdt/statetemplate/6.1.2/css/cagov.font-only.css
-  https://california.azureedge.net/cdt/statetemplate/6.1.2/css/cagov.font-only.min.css
   https://california.azureedge.net/cdt/statetemplate/6.1.2/css/colortheme-delta.css
   https://california.azureedge.net/cdt/statetemplate/6.1.2/css/colortheme-delta.min.css
   https://california.azureedge.net/cdt/statetemplate/6.1.2/css/colortheme-eureka.css
@@ -222,8 +216,6 @@ permalink: "cdn.html"
       <pre>
   <code class="overflow-auto">https://california.azureedge.net/cdt/statetemplate/6.1.1/css/cagov.core.css
   https://california.azureedge.net/cdt/statetemplate/6.1.1/css/cagov.core.min.css
-  https://california.azureedge.net/cdt/statetemplate/6.1.1/css/cagov.font-only.css
-  https://california.azureedge.net/cdt/statetemplate/6.1.1/css/cagov.font-only.min.css
   https://california.azureedge.net/cdt/statetemplate/6.1.1/css/colortheme-delta.css
   https://california.azureedge.net/cdt/statetemplate/6.1.1/css/colortheme-delta.min.css
   https://california.azureedge.net/cdt/statetemplate/6.1.1/css/colortheme-eureka.css
@@ -261,8 +253,6 @@ permalink: "cdn.html"
       <pre>
   <code class="overflow-auto">https://california.azureedge.net/cdt/statetemplate/6.1.0/css/cagov.core.css
   https://california.azureedge.net/cdt/statetemplate/6.1.0/css/cagov.core.min.css
-  https://california.azureedge.net/cdt/statetemplate/6.1.0/css/cagov.font-only.css
-  https://california.azureedge.net/cdt/statetemplate/6.1.0/css/cagov.font-only.min.css
   https://california.azureedge.net/cdt/statetemplate/6.1.0/css/colortheme-delta.css
   https://california.azureedge.net/cdt/statetemplate/6.1.0/css/colortheme-delta.min.css
   https://california.azureedge.net/cdt/statetemplate/6.1.0/css/colortheme-eureka.css
@@ -305,8 +295,6 @@ permalink: "cdn.html"
       <pre>
   <code class="overflow-auto">https://california.azureedge.net/cdt/statetemplate/6.0.9/css/cagov.core.css
   https://california.azureedge.net/cdt/statetemplate/6.0.9/css/cagov.core.min.css
-  https://california.azureedge.net/cdt/statetemplate/6.0.9/css/cagov.font-only.css
-  https://california.azureedge.net/cdt/statetemplate/6.0.9/css/cagov.font-only.min.css
   https://california.azureedge.net/cdt/statetemplate/6.0.9/css/colortheme-delta.css
   https://california.azureedge.net/cdt/statetemplate/6.0.9/css/colortheme-delta.min.css
   https://california.azureedge.net/cdt/statetemplate/6.0.9/css/colortheme-eureka.css
@@ -344,8 +332,6 @@ permalink: "cdn.html"
       <pre>
   <code class="overflow-auto">https://california.azureedge.net/cdt/statetemplate/6.0.8/css/cagov.core.css
   https://california.azureedge.net/cdt/statetemplate/6.0.8/css/cagov.core.min.css
-  https://california.azureedge.net/cdt/statetemplate/6.0.8/css/cagov.font-only.css
-  https://california.azureedge.net/cdt/statetemplate/6.0.8/css/cagov.font-only.min.css
   https://california.azureedge.net/cdt/statetemplate/6.0.8/css/colortheme-delta.css
   https://california.azureedge.net/cdt/statetemplate/6.0.8/css/colortheme-delta.min.css
   https://california.azureedge.net/cdt/statetemplate/6.0.8/css/colortheme-eureka.css


### PR DESCRIPTION
pushing font-only.css removals