### PR TITLE
SEO - fixing bad space added for some canon links

### DIFF
--- a/src/_includes/layouts/base.njk
+++ b/src/_includes/layouts/base.njk
@@ -25,7 +25,7 @@
     {%- if not nocanonical %}
     <!-- Canonical link, improves SEO -->
     <link href="https://template.webstandards.ca.gov{{
-    ("/"+permalink).replace("//"," /") if permalink }}" rel="canonical">
+    ("/"+permalink).replace("//","/") if permalink }}" rel="canonical">
     <!-- END Canonical link -->
     {% endif -%}
     <!-- Open Graph / Facebook -->


### PR DESCRIPTION
fix for extra space in canonical links.

example in...
https://template.webstandards.ca.gov/components/accordion.html

`<link href="https://template.webstandards.ca.gov /components/accordion.html" rel="canonical">`
