### PR TITLE
SEO - adding a rule to stop ads.txt 404

### DIFF
--- a/src/root/robots.txt
+++ b/src/root/robots.txt
@@ -1,4 +1,5 @@
 User-agent: *
 Allow: /
+Disallow: /ads.txt$
 
 Sitemap: https://template.webstandards.ca.gov/sitemap.xml


### PR DESCRIPTION
Google Adware is sending a daily ping to "ads.txt" which is causing a bunch of 404s.  blocking it in robots should stop the 404s.

https://template.webstandards.ca.gov/ads.txt