### PR TITLE
www.ca.gov header/footer utm tags

### DIFF
--- a/src/_includes/global-footer.njk
+++ b/src/_includes/global-footer.njk
@@ -2,7 +2,9 @@
 <footer id="footer" class="global-footer">
   <div class="container">
     <div class="d-flex">
-      <a href="https://ca.gov" class="cagov-logo">
+      <a
+        href="https://www.ca.gov?utm_campaign=state_template_link&utm_medium=footer&utm_source=external"
+        class="cagov-logo">
         <span class="sr-only">CA.gov</span>
         <span class="ca-gov-logo-svg"></span>
       </a>

--- a/src/_includes/utility-header.njk
+++ b/src/_includes/utility-header.njk
@@ -15,10 +15,7 @@
         </p>
       </div>
       <div class="settings-links">
-        <a
-          href="https://github.com/Office-of-Digital-Services/California-State-Web-Template-HTML/releases"
-          >Web template v6.3.1</a
-        >
+        <a href="https://github.com/Office-of-Digital-Services/California-State-Web-Template-HTML/releases">Web template v6.3.1</a>
       </div>
     </div>
   </div>

--- a/src/_includes/utility-header.njk
+++ b/src/_includes/utility-header.njk
@@ -3,7 +3,8 @@
     <div class="flex-row">
       <div class="social-media-links">
         <div class="header-cagov-logo">
-          <a href="https://ca.gov">
+          <a
+            href="https://www.ca.gov?utm_campaign=state_template_link&utm_medium=header&utm_source=external">
             <span class="sr-only">CA.gov</span>
             <span class="ca-gov-logo-svg"></span>
           </a>
@@ -14,7 +15,10 @@
         </p>
       </div>
       <div class="settings-links">
-        <a href="https://github.com/Office-of-Digital-Services/California-State-Web-Template-HTML/releases">Web template v6.3.1</a>
+        <a
+          href="https://github.com/Office-of-Digital-Services/California-State-Web-Template-HTML/releases"
+          >Web template v6.3.1</a
+        >
       </div>
     </div>
   </div>


### PR DESCRIPTION
Adding Analytics tags to site header and footer so ca.gov can track how many people click back from the template.