### PR TITLE
using full canonical link for colors pages

### DIFF
--- a/pages/sample/colortheme.html
+++ b/pages/sample/colortheme.html
@@ -420,7 +420,7 @@ nocanonical: true
   document.getElementsByTagName("head")[0].appendChild(link);
 
   // Add canonical link for SEQ
-  document.head.appendChild(Object.assign(document.createElement('link'),{href:location.href,rel:"canonical"}));
+  document.head.appendChild(Object.assign(document.createElement('link'),{href:"https://template.webstandards.ca.gov"+location.pathname+location.search,rel:"canonical"}));
 
   // add css class "active" to active nav item
   var themeNavItem = document.querySelector("nav.side-navigation a[href*='" + queryString + "']");


### PR DESCRIPTION
hardcoding the final url for canonical to prevent "www." from being indexed.

https://www.template.webstandards.ca.gov/visual-design/color/?santacruz